### PR TITLE
Allow v93k header to use lower case for groups and aliases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,3 @@ DEPENDENCIES
   origen_jtag (>= 0.12.0)
   origen_testers!
   yard-activesupport-concern
-
-BUNDLED WITH
-   1.11.2

--- a/approved/v93k/v93k_workout.avc
+++ b/approved/v93k/v93k_workout.avc
@@ -1,23 +1,25 @@
 # ***************************************************************************
 # GENERATED:
-#   Time:    31-Aug-2015 03:38AM
-#   By:      Stephen McGinty
+#   Time:    20-Apr-2016 16:20PM
+#   By:      Chris Nappi
 #   Command: origen g v93k_workout -t v93k_legacy.rb
 # ***************************************************************************
 # ENVIRONMENT:
 #   Application
 #     Source:    git@github.com:Origen-SDK/origen_testers.git
-#     Version:   0.5.0
-#     Branch:    master(e3384c47ea4) (+local edits)
+#     Version:   0.6.2
+#     Branch:    master(12496eb2cbe) (+local edits)
 #   Origen
 #     Source:    https://github.com/Origen-SDK/origen
-#     Version:   0.2.4
+#     Version:   0.7.0
 #   Plugins
+#     atp:                      0.4.1
 #     origen_arm_debug:         0.4.3
+#     origen_doc_helpers:       0.3.0
 #     origen_jtag:              0.12.0
 #     origen_swd:               0.5.0
 # ***************************************************************************
-FORMAT NVM_RESET NVM_CLK NVM_CLK_MUX PORTA PORTB NVM_INVOKE NVM_DONE NVM_FAIL NVM_ALVTST NVM_AHVTST NVM_DTST TCLK TRST;
+FORMAT nvm_reset nvm_clk nvm_clk_mux porta portb nvm_invoke nvm_done nvm_fail nvm_alvtst nvm_ahvtst nvm_dtst TCLK TRST;
 #                                                   n n n p        p        n n n n n n t t
 #                                                   v v v o        o        v v v v v v c r
 #                                                   m m m r        r        m m m m m m l s

--- a/lib/origen_testers/smartest_based_tester/base.rb
+++ b/lib/origen_testers/smartest_based_tester/base.rb
@@ -338,9 +338,18 @@ module OrigenTesters
         }.merge(options)
         pin_list = ordered_pins.map do |p|
           if Origen.app.pin_pattern_order.include?(p.id)
-            p.id.to_s.upcase # specified name overrides pin name
+            # specified name overrides pin name
+            if p.is_a?(Origen::Pins::PinCollection) || p.id != p.name
+              p.id.to_s # groups or aliases can be lower case
+            else
+              p.id.to_s.upcase # pins must be uppercase
+            end
           else
-            p.name.to_s.upcase
+            if p.is_a?(Origen::Pins::PinCollection) || p.id != p.name
+              p.name.to_s # groups or aliases can be lower case
+            else
+              p.name.to_s.upcase # pins must be uppercase
+            end
           end
         end.join(' ')
         microcode "FORMAT #{pin_list};"


### PR DESCRIPTION
Previously all contents of the header in v93k patterns were forced to uppercase - uppercase is only required for base pin names (the name assigned to a channel).  Aliases and pin groups can have lower case.  