### PR TITLE
Add empty branch cleaner for V93K flow rendering

### DIFF
--- a/approved/v93k/flow_control.aiv
+++ b/approved/v93k/flow_control.aiv
@@ -64,6 +64,7 @@ test22d .tmf
 test22e .tmf
 test22f .tmf
 test3 .tmf
+test36 .tmf
 test4 .tmf
 test5 .tmf
 test6 .tmf

--- a/approved/v93k/flow_control.aiv
+++ b/approved/v93k/flow_control.aiv
@@ -65,6 +65,7 @@ test22e .tmf
 test22f .tmf
 test3 .tmf
 test36 .tmf
+test36b .tmf
 test4 .tmf
 test5 .tmf
 test6 .tmf

--- a/approved/v93k/flow_control.pmfl
+++ b/approved/v93k/flow_control.pmfl
@@ -59,6 +59,7 @@ test22d.binl.gz
 test22e.binl.gz
 test22f.binl.gz
 test3.binl.gz
+test36.binl.gz
 test4.binl.gz
 test5.binl.gz
 test6.binl.gz

--- a/approved/v93k/flow_control.pmfl
+++ b/approved/v93k/flow_control.pmfl
@@ -60,6 +60,7 @@ test22e.binl.gz
 test22f.binl.gz
 test3.binl.gz
 test36.binl.gz
+test36b.binl.gz
 test4.binl.gz
 test5.binl.gz
 test6.binl.gz

--- a/approved/v93k/flow_control.tf
+++ b/approved/v93k/flow_control.tf
@@ -380,6 +380,9 @@ tm_122:
 tm_123:
   "testName" = "Functional";
   "output" = "None";
+tm_124:
+  "testName" = "Functional";
+  "output" = "None";
 end
 --------------------------------------------------
 testmethodlimits
@@ -629,6 +632,8 @@ tm_122:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_123:
   "Functional" = "":"NA":"":"NA":"":"":"";
+tm_124:
+  "Functional" = "":"NA":"":"NA":"":"":"";
 end
 --------------------------------------------------
 testmethods
@@ -877,6 +882,8 @@ tm_121:
 tm_122:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_123:
+  testmethod_class = "ac_tml.AcTest.FunctionalTest";
+tm_124:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 end
 --------------------------------------------------
@@ -1739,6 +1746,13 @@ test22f_BEA7F3B:
   override = 1;
  override_seqlbl = "test22f";
  override_testf = tm_123;
+local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
+ site_match = 2;
+ site_control = "parallel:";
+test36_BEA7F3B:
+  override = 1;
+ override_seqlbl = "test36";
+ override_testf = tm_124;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
@@ -2642,6 +2656,8 @@ test_flow
   else
   {
   }
+  print_dl("This should optimize away then/else branches that are empty");
+  run(test36_BEA7F3B);
 }, open,"FLOW_CONTROL", ""
 end
 -------------------------------------------------

--- a/approved/v93k/flow_control.tf
+++ b/approved/v93k/flow_control.tf
@@ -383,6 +383,9 @@ tm_123:
 tm_124:
   "testName" = "Functional";
   "output" = "None";
+tm_125:
+  "testName" = "Functional";
+  "output" = "None";
 end
 --------------------------------------------------
 testmethodlimits
@@ -634,6 +637,8 @@ tm_123:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_124:
   "Functional" = "":"NA":"":"NA":"":"":"";
+tm_125:
+  "Functional" = "":"NA":"":"NA":"":"":"";
 end
 --------------------------------------------------
 testmethods
@@ -884,6 +889,8 @@ tm_122:
 tm_123:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_124:
+  testmethod_class = "ac_tml.AcTest.FunctionalTest";
+tm_125:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 end
 --------------------------------------------------
@@ -1753,6 +1760,13 @@ test36_BEA7F3B:
   override = 1;
  override_seqlbl = "test36";
  override_testf = tm_124;
+local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
+ site_match = 2;
+ site_control = "parallel:";
+test36b_BEA7F3B:
+  override = 1;
+ override_seqlbl = "test36b";
+ override_testf = tm_125;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
@@ -2658,6 +2672,7 @@ test_flow
   }
   print_dl("This should optimize away then/else branches that are empty");
   run(test36_BEA7F3B);
+  run(test36b_BEA7F3B);
 }, open,"FLOW_CONTROL", ""
 end
 -------------------------------------------------

--- a/approved/v93k/referenced.list
+++ b/approved/v93k/referenced.list
@@ -76,6 +76,7 @@ test22d
 test22e
 test22f
 test3
+test36
 test4
 test5
 test6

--- a/approved/v93k/referenced.list
+++ b/approved/v93k/referenced.list
@@ -77,6 +77,7 @@ test22e
 test22f
 test3
 test36
+test36b
 test4
 test5
 test6

--- a/approved/v93k/test.tf
+++ b/approved/v93k/test.tf
@@ -334,27 +334,9 @@ test_flow
   {
     stop_bin "2", "fail", , bad, noreprobe, red, 119, over_on;
   }
-  run_and_branch(meas_read_pump_5_2D155E0)
-  then
-  {
-  }
-  else
-  {
-  }
-  run_and_branch(meas_read_pump_6_2D155E0)
-  then
-  {
-  }
-  else
-  {
-  }
-  run_and_branch(meas_read_pump_7_2D155E0)
-  then
-  {
-  }
-  else
-  {
-  }
+  run(meas_read_pump_5_2D155E0);
+  run(meas_read_pump_6_2D155E0);
+  run(meas_read_pump_7_2D155E0);
   run_and_branch(meas_read_pump_8_2D155E0)
   then
   {

--- a/lib/origen_testers/smartest_based_tester/base/flow.rb
+++ b/lib/origen_testers/smartest_based_tester/base/flow.rb
@@ -46,6 +46,7 @@ module OrigenTesters
           @stack = { on_fail: [], on_pass: [] }
           m = Processors::IfRanCleaner.new.process(model.ast)
           m = Processors::FlagOptimizer.new.process(m)
+          m = Processors::EmptyBranchCleaner.new.process(m)
           process(m)
         end
 

--- a/lib/origen_testers/smartest_based_tester/base/processors.rb
+++ b/lib/origen_testers/smartest_based_tester/base/processors.rb
@@ -4,6 +4,7 @@ module OrigenTesters
       module Processors
         # Include any V93K specific AST processors here
         autoload :IfRanCleaner, 'origen_testers/smartest_based_tester/base/processors/if_ran_cleaner'
+        autoload :EmptyBranchCleaner, 'origen_testers/smartest_based_tester/base/processors/empty_branch_cleaner'
         autoload :FlagOptimizer, 'origen_testers/smartest_based_tester/base/processors/flag_optimizer'
       end
     end

--- a/lib/origen_testers/smartest_based_tester/base/processors/empty_branch_cleaner.rb
+++ b/lib/origen_testers/smartest_based_tester/base/processors/empty_branch_cleaner.rb
@@ -13,12 +13,12 @@ module OrigenTesters
             end
             node
           end
-          
+
           # Returns true if node is completely empty or if (continue) is only child
           def branch_is_empty?(node)
             children = node.children.dup
             return true if children.nil?
-            first_born = children.shift   
+            first_born = children.shift
             return true if children.empty? && first_born == n0(:continue)
             false
           end

--- a/lib/origen_testers/smartest_based_tester/base/processors/empty_branch_cleaner.rb
+++ b/lib/origen_testers/smartest_based_tester/base/processors/empty_branch_cleaner.rb
@@ -1,0 +1,29 @@
+module OrigenTesters
+  module SmartestBasedTester
+    class Base
+      module Processors
+        class EmptyBranchCleaner < ATP::Processor
+          # Delete any on-fail child if it's 'empty'
+          def on_test(node)
+            on_pass = node.find(:on_pass)
+            on_fail = node.find(:on_fail)
+            unless on_fail.nil?
+              n = node.remove(on_fail) if branch_is_empty?(on_fail)
+              return n
+            end
+            node
+          end
+          
+          # Returns true if node is completely empty or if (continue) is only child
+          def branch_is_empty?(node)
+            children = node.children.dup
+            return true if children.nil?
+            first_born = children.shift   
+            return true if children.empty? && first_born == n0(:continue)
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/origen_testers/smartest_based_tester/base/processors/empty_branch_cleaner.rb
+++ b/lib/origen_testers/smartest_based_tester/base/processors/empty_branch_cleaner.rb
@@ -14,12 +14,32 @@ module OrigenTesters
             node
           end
 
-          # Returns true if node is completely empty or if (continue) is only child
+          # Returns true if:
+          #   - node is completely empty
+          #   - only child is (conitinue) node
+          #   - only two children, one continue and one set-result
           def branch_is_empty?(node)
             children = node.children.dup
             return true if children.nil?
+
+            # only-child situation
             first_born = children.shift
-            return true if children.empty? && first_born == n0(:continue)
+            if children.empty?
+              if first_born == n0(:continue)
+                return true
+              else
+                return false
+              end
+            end
+
+            next_born = children.shift
+            # if only children, check qualificataions, else done and return false
+            if children.empty?
+              if (first_born.type == :continue && next_born.type == :set_result) ||
+                 (first_born.type == :set_result && next_born.type == :continue)
+                return true
+              end
+            end
             false
           end
         end

--- a/lib/origen_testers/smartest_based_tester/base/processors/empty_branch_cleaner.rb
+++ b/lib/origen_testers/smartest_based_tester/base/processors/empty_branch_cleaner.rb
@@ -16,13 +16,13 @@ module OrigenTesters
 
           # Returns true if:
           #   - node is completely empty
-          #   - only child is (conitinue) node
+          #   - only child is (continue) node
           #   - only two children, one continue and one set-result
           def branch_is_empty?(node)
             children = node.children.dup
             return true if children.nil?
 
-            # only-child situation
+            # test for only-child situation
             first_born = children.shift
             if children.empty?
               if first_born == n0(:continue)
@@ -32,8 +32,8 @@ module OrigenTesters
               end
             end
 
+            # if only 2 children, check qualificataions, else done and return false
             next_born = children.shift
-            # if only children, check qualificataions, else done and return false
             if children.empty?
               if (first_born.type == :continue && next_born.type == :set_result) ||
                  (first_born.type == :set_result && next_born.type == :continue)

--- a/program/flow_control.rb
+++ b/program/flow_control.rb
@@ -316,5 +316,6 @@ Flow.create interface: 'OrigenTesters::Test::Interface' do
   if tester.v93k?
     log "This should optimize away then/else branches that are empty"
     func :test36, continue: true
+    func :test36b, bin: 12, continue:true
   end
 end

--- a/program/flow_control.rb
+++ b/program/flow_control.rb
@@ -311,6 +311,10 @@ Flow.create interface: 'OrigenTesters::Test::Interface' do
       func :test22e
       func :test22f
     end 
-  
+  end
+
+  if tester.v93k?
+    log "This should optimize away then/else branches that are empty"
+    func :test36, continue: true
   end
 end


### PR DESCRIPTION
This update optimizes away cases where empty then/else branches get created (V93K-specific)