### PR TITLE
send timeset period to dut.current_timeset_period

### DIFF
--- a/lib/origen_testers/timing.rb
+++ b/lib/origen_testers/timing.rb
@@ -146,14 +146,17 @@ module OrigenTesters
         original = @timeset
         timeset_changed(timeset)
         @timeset = timeset
+        # dut.current_timeset = timeset.name
         dut.current_timeset_period = period_in_ns
         yield
         timeset_changed(original)
         @timeset = original
+        # dut.current_timeset = original.name
         dut.current_timeset_period = original.period_in_ns
       else
         timeset_changed(timeset)
         @timeset = timeset
+        # dut.current_timeset = timeset.name
         dut.current_timeset_period = period_in_ns
       end
     end

--- a/lib/origen_testers/timing.rb
+++ b/lib/origen_testers/timing.rb
@@ -146,12 +146,15 @@ module OrigenTesters
         original = @timeset
         timeset_changed(timeset)
         @timeset = timeset
+        dut.current_timeset_period = period_in_ns
         yield
         timeset_changed(original)
         @timeset = original
+        dut.current_timeset_period = original.period_in_ns
       else
         timeset_changed(timeset)
         @timeset = timeset
+        dut.current_timeset_period = period_in_ns
       end
     end
 

--- a/lib/origen_testers/timing.rb
+++ b/lib/origen_testers/timing.rb
@@ -146,18 +146,18 @@ module OrigenTesters
         original = @timeset
         timeset_changed(timeset)
         @timeset = timeset
-        # dut.current_timeset = timeset.name
-        dut.current_timeset_period = period_in_ns
+        dut.timeset = timeset.name if dut.timesets[timeset.name]
+        dut.current_timeset_period = timeset.period_in_ns
         yield
         timeset_changed(original)
         @timeset = original
-        # dut.current_timeset = original.name
+        dut.timeset = original.name if dut.timesets[original.name]
         dut.current_timeset_period = original.period_in_ns
       else
         timeset_changed(timeset)
         @timeset = timeset
-        # dut.current_timeset = timeset.name
-        dut.current_timeset_period = period_in_ns
+        dut.timeset = timeset.name if dut.timesets[timeset.name]
+        dut.current_timeset_period = timeset.period_in_ns
       end
     end
 


### PR DESCRIPTION
At the moment origen_testers is not sending the current timeset or the current timeset period to the dut.  This PR is to send the timeset period to the dut to avoid run time errors when consuming the new timing api information via wave.evaluated_events.

@ginty I was hesitant to also send the timeset name to dut.current_timeset since this will cause a fail if timeset[id] hasn't been programmed.  How can this be done safely?