### PR TITLE
update test_method to deal with spaces in custom variable names

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base/test_method.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_method.rb
@@ -152,7 +152,7 @@ module OrigenTesters
         end
 
         def clean_attr_name(name)
-          name.to_s.gsub(/\.|-/, '_')
+          name.to_s.gsub(/\.|-|\s+/, '_')
         end
 
         def id=(val)


### PR DESCRIPTION
Since custom parameters are strings in 93k, having spaces is allowed as long as the custom code using those parameters deals with it. This change can handle multiple spaces in the parameter name.