### PR TITLE
Provide access to min_repeat_loop so user can modify if desired.

### DIFF
--- a/lib/origen_testers/igxl_based_tester/base.rb
+++ b/lib/origen_testers/igxl_based_tester/base.rb
@@ -12,6 +12,10 @@ module OrigenTesters
       attr_accessor :default_channelmap
       attr_accessor :default_testerconfig
       attr_accessor :max_site
+      # permit modification of minimum repeat count
+      attr_accessor :min_repeat_loop
+      alias_method :min_repeat_count, :min_repeat_loop
+      alias_method :min_repeat_count=, :min_repeat_loop=
       # NOTE: DO NOT USE THIS CLASS DIRECTLY ONLY USED AS PARENT FOR
       # DESIRED TESTER CLASS
 

--- a/lib/origen_testers/smartest_based_tester/base.rb
+++ b/lib/origen_testers/smartest_based_tester/base.rb
@@ -15,6 +15,11 @@ module OrigenTesters
       # configured to be off by default.
       attr_reader :add_flow_enable
 
+      # permit modification of minimum repeat count
+      attr_accessor :min_repeat_loop
+      alias_method :min_repeat_count, :min_repeat_loop
+      alias_method :min_repeat_count=, :min_repeat_loop=
+
       def initialize(options = {})
         @max_repeat_loop = 65_535
         @min_repeat_loop = 33


### PR DESCRIPTION
Provide accessor for min_repeat_loop so user can change if desired.  Useful for comparing patts between testers. 