### PR TITLE
Fix unique_names bug for v93k flows

### DIFF
--- a/approved/v93k/prb1.tf
+++ b/approved/v93k/prb1.tf
@@ -797,112 +797,112 @@ margin_read1_all1_864CE8F:
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_864CE8F:
+program_ckbd_1_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_11;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_1_864CE8F:
+program_ckbd_2_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_12;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_2_864CE8F:
+program_ckbd_3_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_13;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_3_864CE8F:
+program_ckbd_4_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_14;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_4_864CE8F:
+program_ckbd_5_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_15;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_5_864CE8F:
+program_ckbd_6_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_16;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_6_864CE8F:
+program_ckbd_7_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_17;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_7_864CE8F:
+program_ckbd_8_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_18;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_8_864CE8F:
+program_ckbd_9_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_19;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_9_864CE8F:
+program_ckbd_10_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_20;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_10_864CE8F:
+program_ckbd_11_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_21;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_11_864CE8F:
+program_ckbd_12_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_22;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_12_864CE8F:
+program_ckbd_13_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_23;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_13_864CE8F:
+program_ckbd_14_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_24;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_14_864CE8F:
+program_ckbd_15_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_25;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_15_864CE8F:
+program_ckbd_16_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_26;
@@ -1372,7 +1372,7 @@ some_func_test_864CE8F:
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_16_864CE8F:
+program_ckbd_17_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_93;
@@ -1407,7 +1407,7 @@ bitcell_iv_2_864CE8F:
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-margin_read1_ckbd_864CE8F:
+margin_read1_ckbd_1_864CE8F:
   override = 1;
  override_seqlbl = "margin_read1_ckbd";
  override_testf = tm_98;
@@ -1421,7 +1421,7 @@ normal_read_ckbd_864CE8F:
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-margin_read0_ckbd_864CE8F:
+margin_read0_ckbd_1_864CE8F:
   override = 1;
  override_seqlbl = "margin_read0_ckbd";
  override_testf = tm_100;
@@ -1478,36 +1478,36 @@ test_flow
       }, open,"erase_vfy", ""
     }, open,"erase", ""
     print_dl("Should be v1");
-    run(program_ckbd_864CE8F);
-    print_dl("Should be v2");
     run(program_ckbd_1_864CE8F);
-    print_dl("Should be v1");
-    run(program_ckbd_2_864CE8F);
     print_dl("Should be v2");
+    run(program_ckbd_2_864CE8F);
+    print_dl("Should be v1");
     run(program_ckbd_3_864CE8F);
+    print_dl("Should be v2");
+    run(program_ckbd_4_864CE8F);
     print_dl("Should be a v1 test instance group");
     {
-      run(program_ckbd_4_864CE8F);
       run(program_ckbd_5_864CE8F);
       run(program_ckbd_6_864CE8F);
+      run(program_ckbd_7_864CE8F);
     }, open,"program_ckbd", ""
     print_dl("Should be a v2 test instance group");
     {
-      run(program_ckbd_7_864CE8F);
       run(program_ckbd_8_864CE8F);
       run(program_ckbd_9_864CE8F);
+      run(program_ckbd_10_864CE8F);
     }, open,"program_ckbd_2", ""
     print_dl("Should be a v1 test instance group");
     {
-      run(program_ckbd_10_864CE8F);
       run(program_ckbd_11_864CE8F);
       run(program_ckbd_12_864CE8F);
+      run(program_ckbd_13_864CE8F);
     }, open,"program_ckbd_3", ""
     print_dl("Should be a v2 test instance group");
     {
-      run(program_ckbd_13_864CE8F);
       run(program_ckbd_14_864CE8F);
       run(program_ckbd_15_864CE8F);
+      run(program_ckbd_16_864CE8F);
     }, open,"program_ckbd_4", ""
     if @JOB == "P1" then
     {

--- a/approved/v93k_disable_flow/prb1.tf
+++ b/approved/v93k_disable_flow/prb1.tf
@@ -734,112 +734,112 @@ margin_read1_all1_864CE8F:
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_864CE8F:
+program_ckbd_1_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_11;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_1_864CE8F:
+program_ckbd_2_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_12;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_2_864CE8F:
+program_ckbd_3_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_13;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_3_864CE8F:
+program_ckbd_4_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_14;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_4_864CE8F:
+program_ckbd_5_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_15;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_5_864CE8F:
+program_ckbd_6_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_16;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_6_864CE8F:
+program_ckbd_7_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_17;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_7_864CE8F:
+program_ckbd_8_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_18;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_8_864CE8F:
+program_ckbd_9_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_19;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_9_864CE8F:
+program_ckbd_10_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_20;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_10_864CE8F:
+program_ckbd_11_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_21;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_11_864CE8F:
+program_ckbd_12_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_22;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_12_864CE8F:
+program_ckbd_13_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_23;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_13_864CE8F:
+program_ckbd_14_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_24;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_14_864CE8F:
+program_ckbd_15_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_25;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_15_864CE8F:
+program_ckbd_16_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_26;
@@ -1354,36 +1354,36 @@ test_flow
         }, open,"erase_vfy", ""
       }, open,"erase", ""
       print_dl("Should be v1");
-      run(program_ckbd_864CE8F);
-      print_dl("Should be v2");
       run(program_ckbd_1_864CE8F);
-      print_dl("Should be v1");
-      run(program_ckbd_2_864CE8F);
       print_dl("Should be v2");
+      run(program_ckbd_2_864CE8F);
+      print_dl("Should be v1");
       run(program_ckbd_3_864CE8F);
+      print_dl("Should be v2");
+      run(program_ckbd_4_864CE8F);
       print_dl("Should be a v1 test instance group");
       {
-        run(program_ckbd_4_864CE8F);
         run(program_ckbd_5_864CE8F);
         run(program_ckbd_6_864CE8F);
+        run(program_ckbd_7_864CE8F);
       }, open,"program_ckbd", ""
       print_dl("Should be a v2 test instance group");
       {
-        run(program_ckbd_7_864CE8F);
         run(program_ckbd_8_864CE8F);
         run(program_ckbd_9_864CE8F);
+        run(program_ckbd_10_864CE8F);
       }, open,"program_ckbd_2", ""
       print_dl("Should be a v1 test instance group");
       {
-        run(program_ckbd_10_864CE8F);
         run(program_ckbd_11_864CE8F);
         run(program_ckbd_12_864CE8F);
+        run(program_ckbd_13_864CE8F);
       }, open,"program_ckbd_3", ""
       print_dl("Should be a v2 test instance group");
       {
-        run(program_ckbd_13_864CE8F);
         run(program_ckbd_14_864CE8F);
         run(program_ckbd_15_864CE8F);
+        run(program_ckbd_16_864CE8F);
       }, open,"program_ckbd_4", ""
       if @JOB == "P1" then
       {

--- a/approved/v93k_enable_flow/prb1.tf
+++ b/approved/v93k_enable_flow/prb1.tf
@@ -734,112 +734,112 @@ margin_read1_all1_864CE8F:
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_864CE8F:
+program_ckbd_1_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_11;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_1_864CE8F:
+program_ckbd_2_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_12;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_2_864CE8F:
+program_ckbd_3_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_13;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_3_864CE8F:
+program_ckbd_4_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd";
  override_testf = tm_14;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_4_864CE8F:
+program_ckbd_5_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_15;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_5_864CE8F:
+program_ckbd_6_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_16;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_6_864CE8F:
+program_ckbd_7_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_17;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_7_864CE8F:
+program_ckbd_8_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_18;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_8_864CE8F:
+program_ckbd_9_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_19;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_9_864CE8F:
+program_ckbd_10_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_20;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_10_864CE8F:
+program_ckbd_11_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_21;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_11_864CE8F:
+program_ckbd_12_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_22;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_12_864CE8F:
+program_ckbd_13_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_23;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_13_864CE8F:
+program_ckbd_14_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b0";
  override_testf = tm_24;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_14_864CE8F:
+program_ckbd_15_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b1";
  override_testf = tm_25;
 local_flags  = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
  site_match = 2;
  site_control = "parallel:";
-program_ckbd_15_864CE8F:
+program_ckbd_16_864CE8F:
   override = 1;
  override_seqlbl = "program_ckbd_b2";
  override_testf = tm_26;
@@ -1354,36 +1354,36 @@ test_flow
         }, open,"erase_vfy", ""
       }, open,"erase", ""
       print_dl("Should be v1");
-      run(program_ckbd_864CE8F);
-      print_dl("Should be v2");
       run(program_ckbd_1_864CE8F);
-      print_dl("Should be v1");
-      run(program_ckbd_2_864CE8F);
       print_dl("Should be v2");
+      run(program_ckbd_2_864CE8F);
+      print_dl("Should be v1");
       run(program_ckbd_3_864CE8F);
+      print_dl("Should be v2");
+      run(program_ckbd_4_864CE8F);
       print_dl("Should be a v1 test instance group");
       {
-        run(program_ckbd_4_864CE8F);
         run(program_ckbd_5_864CE8F);
         run(program_ckbd_6_864CE8F);
+        run(program_ckbd_7_864CE8F);
       }, open,"program_ckbd", ""
       print_dl("Should be a v2 test instance group");
       {
-        run(program_ckbd_7_864CE8F);
         run(program_ckbd_8_864CE8F);
         run(program_ckbd_9_864CE8F);
+        run(program_ckbd_10_864CE8F);
       }, open,"program_ckbd_2", ""
       print_dl("Should be a v1 test instance group");
       {
-        run(program_ckbd_10_864CE8F);
         run(program_ckbd_11_864CE8F);
         run(program_ckbd_12_864CE8F);
+        run(program_ckbd_13_864CE8F);
       }, open,"program_ckbd_3", ""
       print_dl("Should be a v2 test instance group");
       {
-        run(program_ckbd_13_864CE8F);
         run(program_ckbd_14_864CE8F);
         run(program_ckbd_15_864CE8F);
+        run(program_ckbd_16_864CE8F);
       }, open,"program_ckbd_4", ""
       if @JOB == "P1" then
       {

--- a/lib/origen_testers/smartest_based_tester/base/test_suites.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_suites.rb
@@ -42,7 +42,7 @@ module OrigenTesters
           @existing_names ||= {}
           if @existing_names[name.to_sym]
             @existing_names[name.to_sym] += 1
-            "#{name}_#{@existing_names[name]}"
+            "#{name}_#{@existing_names[name.to_sym]}"
           else
             @existing_names[name.to_sym] = 0
             name

--- a/lib/origen_testers/smartest_based_tester/base/test_suites.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_suites.rb
@@ -40,11 +40,11 @@ module OrigenTesters
 
         def make_unique(name)
           @existing_names ||= {}
-          if @existing_names[name]
-            @existing_names[name] += 1
+          if @existing_names[name.to_sym]
+            @existing_names[name.to_sym] += 1
             "#{name}_#{@existing_names[name]}"
           else
-            @existing_names[name] = 0
+            @existing_names[name.to_sym] = 0
             name
           end
         end


### PR DESCRIPTION
Force name resolution to symbol (for hash key) in the make_unique method to avoid duplicate test suite names in the case where test_suite-add is done using similar string and symbol (from the flow)

Ex. From _prb1_main.rb that previously generated illegal .tf file with duplicate test suite named 'program_ckbd'.

```code
  func 'program_ckbd', :tname => 'PGM_CKBD', :tnum => 1000, :bin => 100, :soft_bin => 1100

  func :program_ckbd
```


