### PR TITLE
Add plugin specific site_config accessors

### DIFF
--- a/lib/origen_testers.rb
+++ b/lib/origen_testers.rb
@@ -38,6 +38,8 @@ module OrigenTesters
   end
 end
 
+require 'origen_testers/site_config'
+
 require 'origen_testers/igxl_based_tester'
 require 'origen_testers/smartest_based_tester'
 require 'origen_testers/pattern_compilers'

--- a/lib/origen_testers/site_config.rb
+++ b/lib/origen_testers/site_config.rb
@@ -1,0 +1,36 @@
+module OrigenTesters
+  class SiteConfig
+    def initialize
+      @configs ||= Origen.site_config.origen_testers || {}
+    end
+
+    def method_missing(method, *args, &block)
+      method = method.to_s
+      if method =~ /(.*)!$/
+        method = Regexp.last_match(1)
+        must_be_present = true
+      end
+      val = find_val(method)
+      if must_be_present && val.nil?
+        puts "No value assigned for origen_testers site_config attribute '#{method}'"
+        puts
+        fail 'Missing site_config value!'
+      end
+      define_singleton_method(method) do
+        val
+      end
+      val
+    end
+
+    private
+
+    def find_val(val, options = {})
+      config = @configs.find { |c| c.key?(val) }
+      config ? config[val] : nil
+    end
+  end
+
+  def self.site_config
+    @site_config ||= SiteConfig.new
+  end
+end

--- a/origen_site_config.yml
+++ b/origen_site_config.yml
@@ -1,0 +1,11 @@
+# OrigenTesters Example Setup (these are only active when origen_testers is run stand-alone; for specs test)
+#   These yaml definitions should be placed in your top-level application origen_site_config.yml or 
+#   higher up in the site configs of your company-wide origen-core installation.
+#   See http://origen-sdk.org/origen/guides/starting/company for more details.
+origen_testers:
+  - v93k_linux_pattern_compiler: '/company/path/to/v93k/linux/pattern/compiler'
+  - uflex_linux_pattern_compiler: '/company/path/to/uflex/linux/pattern/compiler'
+  - uflex_windows_pattern_compiler: '/company/path/to/uflex/windows/pattern/compiler'
+  - j750_linux_pattern_compiler: '/company/path/to/j750/linux/pattern/compiler'
+  - j750_windows_pattern_compiler: '/company/path/to/j750/windows/pattern/compiler'
+

--- a/spec/site_config_spec.rb
+++ b/spec/site_config_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'OrigenTesters SiteConfig' do
+
+  it 'Gets the origen_testers site configs properly' do
+    OrigenTesters.site_config.v93k_windows_pattern_compiler.should == nil
+
+    OrigenTesters.site_config.j750_linux_pattern_compiler.should == "/company/path/to/j750/linux/pattern/compiler"
+  end
+
+  it 'Properly fails if site config not found and must-be-present (!) is used' do
+    lambda { OrigenTesters.site_config.v93k_windows_pattern_compiler! }.should raise_error
+  end
+end


### PR DESCRIPTION
Syntactic sugar to access origen_testers-specific site configs

Example:
```code
# From origen_site_config.yml
origen_testers:
  - v93k_linux_pattern_compiler: '/company/path/to/v93k/linux/pattern/compiler'
  - uflex_linux_pattern_compiler: '/company/path/to/uflex/linux/pattern/compiler'
  - uflex_windows_pattern_compiler: '/company/path/to/uflex/windows/pattern/compiler'
```
API to access above:
```code
OrigenTesters.site_config.v93k_linux_pattern_compiler  => '/company/path/to/v93k/linux/pattern/compiler'
```