### PR TITLE
Enhanced the unique test name generator 

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base/test_suite.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_suite.rb
@@ -93,8 +93,17 @@ module OrigenTesters
             end
           elsif interface.unique_test_names == :flowname || interface.unique_test_names == :flow_name
             @name = "#{name}_#{interface.flow.name.to_s.symbolize}"
+          elsif interface.unique_test_names == :preflowname || interface.unique_test_names == :pre_flow_name
+            @name = "#{interface.flow.name.to_s.symbolize}_#{name}"
           elsif interface.unique_test_names
-            @name = "#{name}_#{interface.unique_test_names}"
+            utn_string = interface.unique_test_names.to_s
+            if utn_string =~ /^prepend_/
+              utn_string = utn_string.gsub(/^prepend_/, '')
+              @name = "#{utn_string}_#{name}"
+            else
+              utn_string = utn_string.gsub(/^append_/, '')
+              @name = "#{name}_#{utn_string}"
+            end
           end
           # Set the defaults
           DEFAULTS.each do |k, v|

--- a/spec/v93k_unique_test_names_spec.rb
+++ b/spec/v93k_unique_test_names_spec.rb
@@ -87,6 +87,17 @@ describe "V93K unique test name generation" do
     end
   end
 
+  it "Can be set to prepend the flow name at target-level" do
+    with_open_flow target_option: :preflowname do
+      tester.unique_test_names.should == :preflowname
+      interface.new_test(:blah).name.should == "temp_blah"
+    end
+    with_open_flow target_option: :pre_flow_name do
+      tester.unique_test_names.should == :pre_flow_name
+      interface.new_test(:blah).name.should == "temp_blah"
+    end
+  end
+  
   it "Can be set to use a unique string at target-level" do
     with_open_flow target_option: :nvm1 do
       tester.unique_test_names.should == :nvm1
@@ -95,6 +106,21 @@ describe "V93K unique test name generation" do
     with_open_flow target_option: 'nvm2' do
       tester.unique_test_names.should == 'nvm2'
       interface.new_test(:blah).name.should == "blah_nvm2"
+    end
+    with_open_flow target_option: 'append_nvm3' do
+      tester.unique_test_names.should == 'append_nvm3'
+      interface.new_test(:blah).name.should == "blah_nvm3"
+    end
+  end
+
+  it "Can be set to prepend a unique string at target-level" do
+    with_open_flow target_option: :prepend_nvm1 do
+      tester.unique_test_names.should == :prepend_nvm1
+      interface.new_test(:blah).name.should == "nvm1_blah"
+    end
+    with_open_flow target_option: 'prepend_nvm2' do
+      tester.unique_test_names.should == 'prepend_nvm2'
+      interface.new_test(:blah).name.should == "nvm2_blah"
     end
   end
 


### PR DESCRIPTION
Added the ability to prepend flowname or strings to each test:

- :pre_flow_name or :preflowname will put the flow name at the beginning of each test
- :prepend_somestring will add somestring to the beginning of each test
- :append_somestring behaves the same as :somestring