### PR TITLE
Custom v93k flow name

### DIFF
--- a/approved/v93k/flow_control.tf
+++ b/approved/v93k/flow_control.tf
@@ -3420,7 +3420,7 @@ test_flow
     run(test2_26_BEA7F3B);
   }
 
-  }, open,"FLOW_CONTROL",""
+  }, open,"Flow Control Testing",""
 
 end
 -----------------------------------------------------------------

--- a/lib/origen_testers/smartest_based_tester/base/flow.rb
+++ b/lib/origen_testers/smartest_based_tester/base/flow.rb
@@ -9,7 +9,7 @@ module OrigenTesters
         # Returns an array containing all runtime variables which get set by the flow
         attr_reader :set_runtime_variables
 
-        attr_accessor :add_flow_enable
+        attr_accessor :add_flow_enable, :flow_name
 
         def var_filename
           @var_filename || 'global'
@@ -21,6 +21,10 @@ module OrigenTesters
 
         def filename
           super.gsub('_flow', '')
+        end
+
+        def flow_name
+          @flow_name || filename.sub(/\..*/, '').upcase
         end
 
         def hardware_bin_descriptions
@@ -77,7 +81,7 @@ module OrigenTesters
             f << '  }'
           end
           f << ''
-          f << "  }, open,\"#{filename.sub(/\..*/, '').upcase}\",\"\""
+          f << "  }, open,\"#{flow_name}\",\"\""
           f
         end
 

--- a/lib/origen_testers/smartest_based_tester/base/generator.rb
+++ b/lib/origen_testers/smartest_based_tester/base/generator.rb
@@ -22,7 +22,7 @@ module OrigenTesters
         # This will be called at the start of every Flow.create block, :top_level will be
         # true when it is a top-level Flow.create block
         def _internal_startup(options)
-          if options[:top_level] 
+          if options[:top_level]
             if options.key?(:unique_test_names)
               self.unique_test_names = options[:unique_test_names]
             end

--- a/lib/origen_testers/smartest_based_tester/base/generator.rb
+++ b/lib/origen_testers/smartest_based_tester/base/generator.rb
@@ -22,8 +22,11 @@ module OrigenTesters
         # This will be called at the start of every Flow.create block, :top_level will be
         # true when it is a top-level Flow.create block
         def _internal_startup(options)
-          if options[:top_level] && options.key?(:unique_test_names)
-            self.unique_test_names = options[:unique_test_names]
+          if options[:top_level] 
+            if options.key?(:unique_test_names)
+              self.unique_test_names = options[:unique_test_names]
+            end
+            flow.flow_name = options[:flow_name]
           end
         end
 

--- a/program/flow_control.rb
+++ b/program/flow_control.rb
@@ -3,7 +3,7 @@
 # Some of the other flows also cover the flow control API and those tests are used
 # to guarantee that the test ID references work when sub-flows are involved.
 # This flow provides a full checkout of all flow control methods.
-Flow.create interface: 'OrigenTesters::Test::Interface' do
+Flow.create interface: 'OrigenTesters::Test::Interface', flow_name: "Flow Control Testing" do
 
   self.resources_filename = 'flow_control'
 


### PR DESCRIPTION
Enables the user to pass a flow_name: option on the top-level Flow.create line which specifies the name of the top-level group in the output file.  Without flow_name: specified, the behavior defaults to the current: filename.upcase.
