### PR TITLE
fix for origen issue 251

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base/test_method.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_method.rb
@@ -15,6 +15,7 @@ module OrigenTesters
         attr_reader :parameters
         attr_accessor :class_name
         attr_accessor :abs_class_name
+        attr_accessor :limits_id
 
         def initialize(options)
           @type = options[:type]
@@ -25,6 +26,7 @@ module OrigenTesters
           define_singleton_method('limits') do
             @limits
           end
+          @limits_id = options[:methods].delete(:limits_id)
           @limits = TestMethods::Limits.new(self)
           # Add any methods
           if options[:methods][:methods]

--- a/lib/origen_testers/smartest_based_tester/base/test_methods/limits.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_methods/limits.rb
@@ -55,8 +55,12 @@ module OrigenTesters
           private
 
           def test_name
-            name = test_method.test_name if test_method.respond_to?(:test_name)
-            name || 'Functional'
+            if test_method.limits_id.nil?
+              name = test_method.try(:test_name) || test_method.try(:_test_name) || test_method.try('TestName')
+              name || 'Functional'
+            else
+              test_method.limits_id
+            end
           end
         end
       end


### PR DESCRIPTION
This PR allows a test interface to pass a test method parameter :limits_id and set the limits ID in the .tf file.  If it is not passed, the previous behavior is used.  This [issue](https://github.com/Origen-SDK/origen/issues/251) is the basis for the PR.