### PR TITLE
Fixed bug in set_timeset method

### DIFF
--- a/lib/origen_testers/timing.rb
+++ b/lib/origen_testers/timing.rb
@@ -170,10 +170,9 @@ module OrigenTesters
     # @api private
     def _if_dut
       if dut
-        true
+        yield
       else
         Origen.log.warning 'It looks like you are calling tester.set_timeset before the DUT is instantiated, you should avoid doing that until the dut object is available'
-        false
       end
     end
 

--- a/spec/pattern_compilers_spec.rb
+++ b/spec/pattern_compilers_spec.rb
@@ -754,8 +754,6 @@ module CompilerSpec
         dut.pinmap = pinmap
       end
 
-      debugger
-
       it 'fails if dut.pinmap not a file' do
         pinmap = dut.pinmap
         dut.pinmap = 'asdfghjkl'

--- a/spec/timing_spec.rb
+++ b/spec/timing_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe "Timing APIs" do
+
+  it "Setting the tester timeset also updates the DUT" do
+    Origen.environment.temporary = "j750.rb"
+    Origen.load_target("dut.rb")
+    dut.current_timeset_period.should == nil
+    tester.set_timeset("func", 40)
+    dut.current_timeset_period.should == 40
+  end
+end


### PR DESCRIPTION
Due to the way this _if_dut method was originally implemented and used it meant that the code to update the DUT timeset was never triggered.

Added a test to catch it and the appropriate fix.