### PR TITLE
Added handshake overlay style and v93k implementation

### DIFF
--- a/approved/generic_overlay_capture/v93k/test_overlay.avc
+++ b/approved/generic_overlay_capture/v93k/test_overlay.avc
@@ -1,22 +1,22 @@
 # ***************************************************************************
 # GENERATED:
-#   Time:    12-Oct-2017 09:23AM
-#   By:      FSL\b04525
-#   Command: origen g .\pattern\tester_overlay.rb -t dut3.rb -e v93k.rb
+#   Time:    04-Jun-2018 14:01PM
+#   By:      Stephen McGinty
+#   Command: origen g pattern/tester_overlay.rb -t dut3.rb -e v93k.rb
 # ***************************************************************************
 # ENVIRONMENT:
 #   Application
 #     Source:    git@github.com:Origen-SDK/origen_testers.git
-#     Version:   0.13.1
-#     Branch:    repair_overlay(5b780428500) (+local edits)
+#     Version:   0.19.0
+#     Branch:    handshake_overlay(160a8192d3b) (+local edits)
 #   Origen
 #     Source:    https://github.com/Origen-SDK/origen
-#     Version:   0.25.1
+#     Version:   0.27.0
 #   Plugins
-#     atp:                      0.7.0
+#     atp:                      1.1.2
 #     origen_arm_debug:         0.4.3
-#     origen_doc_helpers:       0.5.0
-#     origen_jtag:              0.16.0
+#     origen_doc_helpers:       0.5.1
+#     origen_jtag:              0.17.1
 #     origen_swd:               1.1.0
 # ***************************************************************************
 FORMAT TCLK TDI TDO TMS pa;
@@ -74,6 +74,29 @@ R39                      tp0                        1 1 H 1 101 # ;
 R1                       tp0                        1 1 H 1 101 # ;
 SQPG JSUB global_label_test;
 R1                       tp0                        1 1 H 1 101 # R20 ;
+R1                       tp0                        1 1 H 1 101 # R19 ;
+R1                       tp0                        1 1 H 1 101 # R18 ;
+R1                       tp0                        1 1 H 1 101 # R17 ;
+R1                       tp0                        1 1 H 1 101 # R16 ;
+R1                       tp0                        1 1 H 1 101 # R15 ;
+R1                       tp0                        1 1 H 1 101 # R14 ;
+R1                       tp0                        1 1 H 1 101 # R13 ;
+R1                       tp0                        1 1 H 1 101 # R12 ;
+R1                       tp0                        1 1 H 1 101 # R11 ;
+R1                       tp0                        1 1 H 1 101 # R10 ;
+R1                       tp0                        1 1 H 1 101 # R9 ;
+R1                       tp0                        1 1 H 1 101 # R8 ;
+R1                       tp0                        1 1 H 1 101 # R7 ;
+R1                       tp0                        1 1 H 1 101 # R6 ;
+R1                       tp0                        1 1 H 1 101 # R5 ;
+R1                       tp0                        1 1 H 1 101 # R4 ;
+R1                       tp0                        1 1 H 1 101 # R3 ;
+R1                       tp0                        1 1 H 1 101 # R2 ;
+R1                       tp0                        1 1 H 1 101 # R1 ;
+# ######################################################################
+# ## Now kick the tires of handshake overlay
+# ######################################################################
+R1                       tp0                        1 1 H 1 101 # R20 Now kick the tires of handshake overlay;
 R1                       tp0                        1 1 H 1 101 # R19 ;
 R1                       tp0                        1 1 H 1 101 # R18 ;
 R1                       tp0                        1 1 H 1 101 # R17 ;

--- a/approved/generic_overlay_capture/v93k/test_overlay_part1.avc
+++ b/approved/generic_overlay_capture/v93k/test_overlay_part1.avc
@@ -1,0 +1,50 @@
+# ***************************************************************************
+# GENERATED:
+#   Time:    04-Jun-2018 14:01PM
+#   By:      Stephen McGinty
+#   Command: origen g pattern/tester_overlay.rb -t dut3.rb -e v93k.rb
+# ***************************************************************************
+# ENVIRONMENT:
+#   Application
+#     Source:    git@github.com:Origen-SDK/origen_testers.git
+#     Version:   0.19.0
+#     Branch:    handshake_overlay(160a8192d3b) (+local edits)
+#   Origen
+#     Source:    https://github.com/Origen-SDK/origen
+#     Version:   0.27.0
+#   Plugins
+#     atp:                      1.1.2
+#     origen_arm_debug:         0.4.3
+#     origen_doc_helpers:       0.5.1
+#     origen_jtag:              0.17.1
+#     origen_swd:               1.1.0
+# ***************************************************************************
+FORMAT TCLK TDI TDO TMS pa;
+#                                                   t t t t p  
+#                                                   c d d m a  
+#                                                   l i o s    
+#                                                   k          
+R1                       tp0                        1 1 H 1 101 # R20 ;
+R1                       tp0                        1 1 H 1 101 # R19 ;
+R1                       tp0                        1 1 H 1 101 # R18 ;
+R1                       tp0                        1 1 H 1 101 # R17 ;
+R1                       tp0                        1 1 H 1 101 # R16 ;
+R1                       tp0                        1 1 H 1 101 # R15 ;
+R1                       tp0                        1 1 H 1 101 # R14 ;
+R1                       tp0                        1 1 H 1 101 # R13 ;
+R1                       tp0                        1 1 H 1 101 # R12 ;
+R1                       tp0                        1 1 H 1 101 # R11 ;
+R1                       tp0                        1 1 H 1 101 # R10 ;
+R1                       tp0                        1 1 H 1 101 # R9 ;
+R1                       tp0                        1 1 H 1 101 # R8 ;
+R1                       tp0                        1 1 H 1 101 # R7 ;
+R1                       tp0                        1 1 H 1 101 # R6 ;
+R1                       tp0                        1 1 H 1 101 # R5 ;
+R1                       tp0                        1 1 H 1 101 # R4 ;
+R1                       tp0                        1 1 H 1 101 # R3 ;
+R1                       tp0                        1 1 H 1 101 # R2 ;
+R1                       tp0                        1 1 H 1 101 # R1 ;
+# ######################################################################
+# ## Pattern complete
+# ######################################################################
+SQPG STOP;

--- a/lib/origen_testers/smartest_based_tester/base.rb
+++ b/lib/origen_testers/smartest_based_tester/base.rb
@@ -147,16 +147,29 @@ module OrigenTesters
             when :subroutine, :default
               subroutine_overlay(overlay_str, options)
               ovly_style = :subroutine
+            when :handshake
+              if @delayed_handshake
+                if @delayed_handshake != overlay_str
+                  handshake
+                  @delayed_handshake = overlay_str
+                end
+              else
+                @delayed_handshake = overlay_str
+              end
             else
               ovly_style = overlay_style_warn(options[:overlay][:overlay_str], options)
           end # case ovly_style
         else
+          handshake if @delayed_handshake
+          @delayed_handshake = nil
           @overlay_subr = nil
         end # of handle overlay
 
         options_overlay = options.delete(:overlay) if options.key?(:overlay)
 
-        super(options) unless ovly_style == :subroutine
+        unless ovly_style == :subroutine || ovly_style == :handshake
+          super(options)
+        end
 
         unless options_overlay.nil?
           # stage = :body if ovly_style == :subroutine 		# always set stage back to body in case subr overlay was selected

--- a/pattern/tester_overlay.rb
+++ b/pattern/tester_overlay.rb
@@ -59,4 +59,15 @@ Pattern.create(name: "test_overlay") do
   tester.cycle inline_comment: '2nd line after global label for overlay', overlay: {overlay_str: 'global_label_test', pins: dut.pin(:pa)}
   tester.cycle inline_comment: '3rd line after global label for overlay', overlay: {overlay_str: 'global_label_test', pins: dut.pin(:pa)}
   tester.cycle repeat: 20
+
+  if tester.v93k?
+    ss "Now kick the tires of handshake overlay"
+    tester.cycle repeat: 20
+    tester.overlay_style = :handshake
+    dut.pin(:pa).drive(5)
+    tester.cycle inline_comment: '1st line after global label for overlay', overlay: {overlay_str: 'global_label_test', pins: dut.pin(:pa)}
+    tester.cycle inline_comment: '2nd line after global label for overlay', overlay: {overlay_str: 'global_label_test', pins: dut.pin(:pa)}
+    tester.cycle inline_comment: '3rd line after global label for overlay', overlay: {overlay_str: 'global_label_test', pins: dut.pin(:pa)}
+    tester.cycle repeat: 20
+  end
 end


### PR DESCRIPTION
Adds a new overlay_style called :handshake and has an implementation of it on V93K.

In principle it is designed for when you want to implement the overlay using vectors generated in the ATE language, e.g. SmartVec/RDI on the 93K.

So whenever such an overlay is encountered, the overlay vectors are inhibited in the same as they are with the existing subroutine style of overlay, but instead of calling a subroutine it instead does a handshake with the tester.
That is implemented by simply calling the existing handshake API, which for the 93K will split the pattern at that point.

A doc update for it is in this PR - https://github.com/Origen-SDK/origen/pull/268

