### PR TITLE
correct verbose inline vector comments with group_size > 1

### DIFF
--- a/lib/origen_testers/vector_pipeline.rb
+++ b/lib/origen_testers/vector_pipeline.rb
@@ -1,3 +1,5 @@
+# vector_pipeline concept explained [here](https://github.com/Origen-SDK/origen_testers/pull/101#issuecomment-424768720)
+
 module OrigenTesters
   class VectorPipeline
     attr_reader :group_size, :pipeline
@@ -130,11 +132,11 @@ module OrigenTesters
           yield vector
         end
         @vector_count += r
-        # @cycle_count += r unless @group_size > 1 && lead_group.last.repeat > 1
+        # @cycle_count now tracked in the calling methods (flush and empty)
       else
         yield vector
         @vector_count += 1
-        # @cycle_count += r * @group_size
+        # @cycle_count now tracked in the calling methods (flush and empty)
       end
     end
 

--- a/lib/origen_testers/vector_pipeline.rb
+++ b/lib/origen_testers/vector_pipeline.rb
@@ -124,7 +124,7 @@ module OrigenTesters
       else
         yield vector
         @vector_count += 1
-        @cycle_count += r
+        @cycle_count += r * @group_size
       end
     end
 

--- a/lib/origen_testers/vector_pipeline.rb
+++ b/lib/origen_testers/vector_pipeline.rb
@@ -89,19 +89,18 @@ module OrigenTesters
         end
 
         duplicate_last_vector until aligned?
-        ugly_i = 0
-        ugly_c = @group_size - 1
-        pipeline.each do |vector|
+
+        group_repeat_index = @group_size - 1
+        pipeline.each_index do |index|
+          vector = pipeline[index]
           vector.comments.each do |comment|
             yield comment
           end
           yield_vector(vector, &block)
-          @cycle_count += pipeline[ugly_c].repeat
-          ugly_i += 1
-          if ugly_i == @group_size
-            ugly_i = 0
-            ugly_c += @group_size
+          if index % @group_size == 0 && index > 0
+            group_repeat_index += @group_size
           end
+          @cycle_count += pipeline[group_repeat_index].repeat
         end
 
         comments.each do |comment|

--- a/lib/origen_testers/vector_pipeline.rb
+++ b/lib/origen_testers/vector_pipeline.rb
@@ -67,6 +67,7 @@ module OrigenTesters
             yield comment
           end
           yield_vector(vector, &block)
+          @cycle_count += pipeline[@group_size - 1].repeat
         end
         pipeline.shift(group_size)
       end
@@ -83,14 +84,24 @@ module OrigenTesters
               comment_written = true
             end
             yield_vector(@last_vector, &block)
+            @cycle_count += @last_vector.repeat
           end
         end
+
         duplicate_last_vector until aligned?
+        ugly_i = 0
+        ugly_c = @group_size - 1
         pipeline.each do |vector|
           vector.comments.each do |comment|
             yield comment
           end
           yield_vector(vector, &block)
+          @cycle_count += pipeline[ugly_c].repeat
+          ugly_i += 1
+          if ugly_i == @group_size
+            ugly_i = 0
+            ugly_c += @group_size
+          end
         end
 
         comments.each do |comment|
@@ -120,11 +131,11 @@ module OrigenTesters
           yield vector
         end
         @vector_count += r
-        @cycle_count += r
+        # @cycle_count += r unless @group_size > 1 && lead_group.last.repeat > 1
       else
         yield vector
         @vector_count += 1
-        @cycle_count += r * @group_size
+        # @cycle_count += r * @group_size
       end
     end
 


### PR DESCRIPTION
When tester.vector_group_size is > 1 and the "-v" generate option is used, the inline cycle comment was incorrect. This fixes it. But, I couldn't figure out a way to explicitly test it. Any test suggestions?