### PR TITLE
needed to make site_control and site_match programmable

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base/test_suite.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_suite.rb
@@ -37,6 +37,8 @@ module OrigenTesters
              ffv_enable
              frg_enable
              hardware_dsp_disable
+             site_control
+             site_match
           )
 
         ALIASES = {
@@ -67,7 +69,9 @@ module OrigenTesters
           pass_value:      true,
           fail_value:      true,
           per_pin_on_pass: true,
-          per_pin_on_fail: true
+          per_pin_on_fail: true,
+          site_control:    "parallel:",
+          site_match:      2
         }
 
         # Generate accessors for all attributes and their aliases
@@ -148,8 +152,8 @@ module OrigenTesters
           l << "  override_tim_equ_set = #{wrap_if_string(timing_equation)};" if timing_equation
           l << "  override_tim_spec_set = #{wrap_if_string(timing_spec)};" if timing_spec
           l << "  override_timset = #{wrap_if_string(timing_set)};" if timing_set
-          l << '  site_control = "parallel:";'
-          l << '  site_match = 2;'
+          l << "  site_control = #{wrap_if_string(site_control)};" if site_control
+          l << "  site_match = #{wrap_if_string(site_match)};" if site_match
           l << "  test_level = #{test_level};" if test_level
           l
         end
@@ -199,6 +203,8 @@ module OrigenTesters
           f << 'ffv_enable' if ffv_enable
           f << 'frg_enable' if frg_enable
           f << 'hw_dsp_disable' if hardware_dsp_disable
+          f << 'site_control' if site_control
+          f << 'site_match' if site_match
           f.join(', ')
         end
 

--- a/lib/origen_testers/smartest_based_tester/base/test_suite.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_suite.rb
@@ -70,7 +70,7 @@ module OrigenTesters
           fail_value:      true,
           per_pin_on_pass: true,
           per_pin_on_fail: true,
-          site_control:    "parallel:",
+          site_control:    'parallel:',
           site_match:      2
         }
 

--- a/lib/origen_testers/smartest_based_tester/base/test_suite.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_suite.rb
@@ -203,8 +203,6 @@ module OrigenTesters
           f << 'ffv_enable' if ffv_enable
           f << 'frg_enable' if frg_enable
           f << 'hw_dsp_disable' if hardware_dsp_disable
-          f << 'site_control' if site_control
-          f << 'site_match' if site_match
           f.join(', ')
         end
 


### PR DESCRIPTION
There are some search test methods that cannot be run in parallel mode.