### PR TITLE
print svm_subr optional for non uflex only.

### DIFF
--- a/lib/origen_testers/igxl_based_tester/base.rb
+++ b/lib/origen_testers/igxl_based_tester/base.rb
@@ -669,7 +669,9 @@ module OrigenTesters
         unless options[:group]    # Withhold imports for pattern groups, is this correct?
           called_subroutines.each do |sub_name|
             # Don't import any called subroutines that are declared in the current pattern
-            microcode "import svm_subr #{sub_name};" unless local_subroutines.include?(sub_name)
+            unless local_subroutines.include?(sub_name)
+              microcode "import svm_subr #{sub_name};" unless uflex?
+            end
           end
         end
 


### PR DESCRIPTION
the microcode printout "svm_subr" only for IGXL of J750 and Flex, but not UltraFlex.
Thus bypass this print works well too, since in Uflex pattern compiler there's an "import undefineds" option to overcome this.