### PR TITLE
Added support for boolean types in V93K test method attributes

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base/test_method.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_method.rb
@@ -2,7 +2,7 @@ module OrigenTesters
   module SmartestBasedTester
     class Base
       class TestMethod
-        FORMAT_TYPES = [:current, :voltage, :time, :string, :integer, :double]
+        FORMAT_TYPES = [:current, :voltage, :time, :string, :integer, :double, :boolean]
 
         # Returns the object representing the test method library that the
         # given test method is defined in
@@ -109,8 +109,21 @@ module OrigenTesters
             "#{val}[s]"
           when :frequency
             "#{val}[Hz]"
-          when :string, :integer, :double
+          when :string
             val.to_s
+          when :integer, :double
+            val
+          when :boolean
+            # Check for valid values
+            if [0, 1, true, false].include?(val)
+              if [1, true].include?(val)
+                1
+              else
+                0
+              end
+            else
+              fail "Unknown boolean value for attribute #{attr}: #{val}"
+            end
           else
             fail "Unknown type for attribute #{attr}: #{type}"
           end

--- a/templates/origen_guides/program/v93k.md.erb
+++ b/templates/origen_guides/program/v93k.md.erb
@@ -240,7 +240,7 @@ module Vreg
           # the camel cased version, starting with a lower-cased letter, i.e. 'testerState' in this
           # first example.
           # The attribute definition has two required parameters, the type and the default value.
-          # The type can be :string, :current, :voltage, :time, :frequency, or :integer 
+          # The type can be :string, :current, :voltage, :time, :frequency, integer, :double or :boolean
           pin_list: [:string, ''],
           samples: [:integer, 1],
           precharge_voltage: [:voltage, 0],


### PR DESCRIPTION
This allows custom test method definitions for the V93K (SMT7) to declare attributes as boolean type and then assign them true/false and they will be rendered as a 1/0 integer.

This update has been on the SMT8 branch for a long time, but bringing it over to the mainline since its usage has crept into origen_std_lib.