### PR TITLE
Add flow bypass, group bypass and group comment options

### DIFF
--- a/approved/v93k/flow_control.tf
+++ b/approved/v93k/flow_control.tf
@@ -3042,8 +3042,8 @@ test_flow
           else
           {
           }
-       }, open,"level2", ""
-    }, open,"level1", ""
+       },groupbypass,  open,"level2", ""
+    }, open,"level1", "Level 1 Group"
     print_dl("Test nested conditions on a group");
     run_and_branch(nt1_BEA7F3B)
     then

--- a/approved/v93k/prb2.tf
+++ b/approved/v93k/prb2.tf
@@ -206,7 +206,7 @@ test_flow
     {
     }
 
-  }, open,"PRB2","An example of creating an entire test program from a single source file"
+  },groupbypass,  open,"PRB2","An example of creating an entire test program from a single source file"
 
 end
 -----------------------------------------------------------------

--- a/approved/v93k_disable_flow/prb2.tf
+++ b/approved/v93k_disable_flow/prb2.tf
@@ -206,7 +206,7 @@ test_flow
     {
     }
 
-  }, open,"PRB2","An example of creating an entire test program from a single source file"
+  },groupbypass,  open,"PRB2","An example of creating an entire test program from a single source file"
 
 end
 -----------------------------------------------------------------

--- a/approved/v93k_enable_flow/prb2.tf
+++ b/approved/v93k_enable_flow/prb2.tf
@@ -206,7 +206,7 @@ test_flow
     {
     }
 
-  }, open,"PRB2","An example of creating an entire test program from a single source file"
+  },groupbypass,  open,"PRB2","An example of creating an entire test program from a single source file"
 
 end
 -----------------------------------------------------------------

--- a/approved/v93k_global/prb2.tf
+++ b/approved/v93k_global/prb2.tf
@@ -206,7 +206,7 @@ test_flow
     {
     }
 
-  }, open,"PRB2","An example of creating an entire test program from a single source file"
+  },groupbypass,  open,"PRB2","An example of creating an entire test program from a single source file"
 
 end
 -----------------------------------------------------------------

--- a/lib/origen_testers/atp/flow.rb
+++ b/lib/origen_testers/atp/flow.rb
@@ -226,6 +226,10 @@ module OrigenTesters::ATP
       extract_meta!(options) do
         apply_conditions(options) do
           children = [n1(:name, name)]
+          children << n1(:bypass, options[:bypass]) if options[:bypass]
+          if options[:comment] || options[:description] || options[:desc]
+            children << n1(:comment, options[:comment] || options[:description] || options[:desc])
+          end
           children << id(options[:id]) if options[:id]
           children << on_fail(options[:on_fail]) if options[:on_fail]
           children << on_pass(options[:on_pass]) if options[:on_pass]

--- a/lib/origen_testers/atp/processors/condition.rb
+++ b/lib/origen_testers/atp/processors/condition.rb
@@ -53,14 +53,28 @@ module OrigenTesters::ATP
       end
 
       def on_group(node)
-        name, *nodes = *node
+        array_for_update = []
+        if node.find(:bypass) && node.find(:comment)
+          name, bypass, comment, *nodes = *node
+          array_for_update = [name, bypass, comment]
+        elsif node.find(:bypass)
+          name, bypass, *nodes = *node
+          array_for_update = [name, bypass]
+        elsif node.find(:comment)
+          name, comment, *nodes = *node
+          array_for_update = [name, comment]
+        else
+          name, *nodes = *node
+          array_for_update = [name]
+        end
+
         if conditions_to_remove.any? { |c| node.type == c.type && c.to_a == [name] }
-          conditions_to_remove << node.updated(nil, [name])
+          conditions_to_remove << node.updated(nil, array_for_update)
           result = node.updated(:inline, optimize(process_all(nodes)))
           conditions_to_remove.pop
         else
-          conditions_to_remove << node.updated(nil, [name])
-          result = node.updated(nil, [name] + optimize(process_all(nodes)))
+          conditions_to_remove << node.updated(nil, [name, bypass, comment])
+          result = node.updated(nil, array_for_update + optimize(process_all(nodes)))
           conditions_to_remove.pop
         end
         result

--- a/lib/origen_testers/smartest_based_tester/base/flow.rb
+++ b/lib/origen_testers/smartest_based_tester/base/flow.rb
@@ -334,7 +334,7 @@ module OrigenTesters
 
           bypass = node.find(:bypass).try(:value) || false
           comment = node.find(:comment).try(:value) || ''
-          if node.find(:bypass).try(:value)
+          if bypass
             line "},groupbypass,  open,\"#{unique_group_name(node.find(:name).value)}\", \"#{comment}\""
           else
             line "}, open,\"#{unique_group_name(node.find(:name).value)}\", \"#{comment}\""

--- a/lib/origen_testers/smartest_based_tester/base/generator.rb
+++ b/lib/origen_testers/smartest_based_tester/base/generator.rb
@@ -27,6 +27,7 @@ module OrigenTesters
               self.unique_test_names = options[:unique_test_names]
             end
             flow.flow_name = options[:flow_name]
+            flow.flow_bypass = options[:flow_bypass].nil? ? false : options[:flow_bypass]
             flow.flow_description = options[:flow_description] || OrigenTesters::Flow.flow_comments.join(' ')
           end
         end

--- a/program/flow_control.rb
+++ b/program/flow_control.rb
@@ -174,13 +174,13 @@ Flow.create interface: 'OrigenTesters::Test::Interface', flow_name: "Flow Contro
   func :gt3, bin: 90, if_failed: :gt_grp2, number: 50730
 
   log "Test that nested groups work"
-  group "level1" do
+  group "level1", comment: "Level 1 Group" do
     func :lev1_test1, bin: 5, number: 50740
     func :lev1_test2, bin: 5, number: 50750
     func :lev1_test3, id: :l1t3, bin: 10, number: 50760
     func :lev1_test4, if_failed: :l1t3, bin: 12, number: 50770
     func :lev1_test5, id: :l1t5, bin: 12, number: 50780
-    group "level2" do
+    group "level2", bypass: true do
       func :lev2_test1, bin: 5, number: 50790
       func :lev2_test2, bin: 5, number: 50800
       func :lev2_test3, id: :l2t3, bin: 10, number: 50810

--- a/program/prb2.rb
+++ b/program/prb2.rb
@@ -1,6 +1,6 @@
 # An example of creating an entire test program from
 # a single source file
-Flow.create interface: 'OrigenTesters::Test::Interface' do
+Flow.create interface: 'OrigenTesters::Test::Interface', flow_bypass: true do
 
   # Test that this can be overridden from the target at flow-level
   self.add_flow_enable = :enabled


### PR DESCRIPTION
Add flow bypass option:

~~~ruby
Flow.create interface: 'My::Interface', flow_bypass: true do
  test :test1
end

Flow.create interface: 'My::Interface' do
  flow.flow_bypass = true
  test :test1
end
~~~

Add group bypass option:

~~~ruby
group :my_group, bypass: true do
  test :test1
end
~~~

Add group comment/description options;

~~~ruby
group :my_other_group, comment: "This is the other group" do
  test :test1
end
~~~
