### PR TITLE
DRY flow works but not sure if this is the correct implementation

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base/test_suite.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_suite.rb
@@ -2,10 +2,18 @@ module OrigenTesters
   module SmartestBasedTester
     class Base
       class TestSuite
-        attr_accessor :meta
+        attr_accessor :meta, :programmed_parameters
 
         def initialize(name, attrs = {})
           @name = name
+          unless attrs[:programmed_params].nil?
+            unless attrs[:programmed_params].is_a? Array
+              Origen.log.error('Test suite user programmed parameters must be passed as an Array of test method parameters')
+              fail
+            end
+            @programmed_parameters = attrs[:programmed_params].map { |id| new_id = id.to_s;  new_id.include?('_') ? new_id.gsub('_', '.') : new_id }
+            attrs.delete :programmed_params
+          end
           if interface.unique_test_names == :signature
             if interface.flow.sig
               @name = "#{name}_#{interface.flow.sig}"

--- a/lib/origen_testers/smartest_based_tester/base/test_suites.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_suites.rb
@@ -22,6 +22,9 @@ module OrigenTesters
         end
 
         def add(name, options = {})
+          options = {
+            programmed_params: nil
+          }.merge!(options)
           symbol = name.is_a?(Symbol)
           name = make_unique(name)
           # Ensure names given as a symbol stay as a symbol, this is more for

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/test_suite.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/test_suite.rb
@@ -50,7 +50,8 @@ module OrigenTesters
           if specification && !specification.to_s.empty?
             l << "    measurement.specification = setupRef(#{tester.package_namespace}.specs.#{specification});"
           end
-          test_method.sorted_parameters.each do |param|
+          parameters_to_include = programmed_parameters.nil? ? test_method.sorted_parameters : filter_parameters(test_method.sorted_parameters)
+          parameters_to_include.each do |param|
             name = param[0]
             unless name.is_a?(String)
               name = name.to_s[0] == '_' ? name.to_s.camelize(:upper) : name.to_s.camelize(:lower)
@@ -59,6 +60,18 @@ module OrigenTesters
           end
           l << '}'
           l
+        end
+
+        private
+
+        def filter_parameters(param_ary)
+          [].tap do |filtered_ary|
+            param_ary.each do |param_definition|
+              name = param_definition.first
+              next unless programmed_parameters.include? name
+              filtered_ary << param_definition
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Will not work for SMT7 as currently architected due to the fact that SMT7 does not store the lines to be printed to the ERB template in an object.  Rather it finds the test method parameter values in the [ERB template](https://github.com/Origen-SDK/origen_testers/blob/master/lib/origen_testers/smartest_based_tester/v93k/templates/template.tf.erb#L140-L145).  Whereas the SMT8 implementation keeps the flow file lines stored as part of the [test suite instance](https://github.com/Origen-SDK/origen_testers/blob/master/lib/origen_testers/smartest_based_tester/v93k_smt8/test_suite.rb#L53-L59).


Here is how I added the programmed parameters in my test interface:

~~~ruby
      test_suite_opts = test_instance.primaries.merge(test_instance.flags).merge( { programmed_params: test_instance.test_method_params.ids })
      t = test_suites.add(test_instance.test_suite_name, test_suite_opts)
~~~