### PR TITLE
The avc_digcap_vpf method does not handle looping correctly #145

### DIFF
--- a/lib/origen_testers/pattern_compilers/v93k.rb
+++ b/lib/origen_testers/pattern_compilers/v93k.rb
@@ -312,10 +312,14 @@ module OrigenTesters
       # Given the file contents, parse and calculate number of capture vectors
       def avc_digcap_vpf(contents)
         capture_vectors = 0
+        factor = 1
         contents.each_line do |line|
-          if line[0] != "\#"     # skip any comment lines
-            capture_vectors += 1 if /#{digcap.capture_string}/.match(line)
+          next if line.match(/^\s*\#/)
+          if line.match(/^\s*SQPG\s+LBGN\s+(\d+)\s*;/)
+            factor = Regexp.last_match(1).to_i
           end
+          factor = 1 if line.match(/^\s*SQPG\s+LEND\s*;/)
+          capture_vectors += factor if /#{digcap.capture_string}/.match(line)
         end
         capture_vectors
       end


### PR DESCRIPTION
Issue #145:

The avc_digcap_vpf method in lib/origen_testers/pattern_compilers/v93k.rb increments the capture_vectors variable by one for each appearance of the digcap.capture_string string. This does not take into account of vector looping which is used in the MTR bitmapping patterns