### PR TITLE
Skip dig src start

### DIFF
--- a/approved/generic_overlay_capture/ultraflex/test_overlay_no_start.atp
+++ b/approved/generic_overlay_capture/ultraflex/test_overlay_no_start.atp
@@ -1,0 +1,123 @@
+// ***************************************************************************
+// GENERATED:
+//   Time:    30-Mar-2020 14:55PM
+//   By:      Paul DeRouen
+//   Mode:    debug
+//   Command: origen g tester_overlay_no_start -t dut3.rb -e uflex.rb
+// ***************************************************************************
+// ENVIRONMENT:
+//   Application
+//     Source:    git@github.com:Origen-SDK/origen_testers.git
+//     Version:   0.45.3
+//     Branch:    SkipDigSrcStart(bd22f83fd80) (+local edits)
+//   Origen
+//     Source:    https://github.com/Origen-SDK/origen
+//     Version:   0.55.1
+//   Plugins
+//     origen_arm_debug:         0.4.3
+//     origen_doc_helpers:       0.8.2
+//     origen_jtag:              0.22.0
+//     origen_stil:              0.2.1
+//     origen_swd:               1.1.2
+// ***************************************************************************
+//   DigSrc SEND count for tdi: 1                                                               
+//   DigSrc SEND count for pa: 6                                                                
+import tset tp0;                                                                                
+opcode_mode = single;                                                                           
+digital_inst = hsdm;                                                                            
+compressed = yes;                                                                               
+instruments = {                                                                                 
+               (tdi):DigSrc 32:serial:lsb;                                                      
+               (pa):DigSrc 3;                                                                   
+}                                                                                               
+                                                                                                
+vm_vector                                                                                       
+test_overlay_no_start ($tset, tclk, tdi, tdo, tms, pa)                                          
+{                                                                                               
+start_label test_overlay_no_start_st:                                                           
+//                                                                                              t t t t p  
+//                                                                                              c d d m a  
+//                                                                                              l i o s    
+//                                                                                              k          
+// should get a repeat count added to this vector for digsrc start minimum distance
+                                                                 > tp0                          X X X X XXX ;
+// should get a repeat 5 vector
+repeat 5                                                         > tp0                          1 1 H 1 XXX ;
+// should get a send microcode and 1 cycle with D
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > tp0                          1 D H 1 XXX ;
+// should get a cycle with D and no send
+                                                                 > tp0                          1 D H 1 XXX ;
+// regular cycle with no D or send
+                                                                 > tp0                          1 1 H 1 XXX ;
+// cycle with 001 on pa
+                                                                 > tp0                          1 1 H 1 001 ;
+// send microcode followed by DDD on pa
+((pa):DigSrc = SEND)                                                                            
+                                                                 > tp0                          1 1 H 1 DDD ;
+// cycle with 001 on pa
+                                                                 > tp0                          1 1 H 1 001 ;
+// send microcode, DDD on pa with repeat 5 (will send 5 sets of data)
+((pa):DigSrc = SEND)                                                                            
+repeat 5                                                         > tp0                          1 1 H 1 DDD ;
+// cycle with 001 on pa
+                                                                 > tp0                          1 1 H 1 001 ;
+// ######################################################################
+// ## Pattern complete
+// ######################################################################
+// PADDING VECTORS ADDED TO MEET MIN 64 FOR PATTERN
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+                                                                 > tp0                          1 1 H 1 001 ;
+}                                                                                               

--- a/examples/pattern_generator.rb
+++ b/examples/pattern_generator.rb
@@ -29,7 +29,7 @@ load "#{Origen.top}/lib/origen/commands/generate.rb"
 ARGV = %w(regression.list -t dut.rb -e v93k_smt8.rb -r approved/v93k_smt8)
 load "#{Origen.top}/lib/origen/commands/generate.rb"
 
-ARGV = %w(tester_overlay tester_store -t dut3.rb -e uflex -r approved/generic_overlay_capture/ultraflex)
+ARGV = %w(tester_overlay tester_store tester_overlay_no_start -t dut3.rb -e uflex -r approved/generic_overlay_capture/ultraflex)
 load "#{Origen.top}/lib/origen/commands/generate.rb"
 
 ARGV = %w(tester_overlay tester_store -t dut3.rb -e j750.rb -r approved/generic_overlay_capture/j750)

--- a/lib/origen_testers/igxl_based_tester/base.rb
+++ b/lib/origen_testers/igxl_based_tester/base.rb
@@ -1054,7 +1054,7 @@ module OrigenTesters
           Origen.log.warn 'tester.digsrc_skip_start must be called before any overlay actions on the pin'
         end
       end
-      
+
       # Perform digsrc overlay (called by tester.cycle)
       def digsrc_overlay(options = {})
         options[:overlay] = { change_data: true }.merge(options[:overlay])

--- a/lib/origen_testers/igxl_based_tester/base.rb
+++ b/lib/origen_testers/igxl_based_tester/base.rb
@@ -1041,6 +1041,20 @@ module OrigenTesters
         # stage = sub_name
       end # subroutine_overlay
 
+      # Disable the automatic addition of the digsrc start command at the beginning of the pattern
+      #
+      # @example
+      #   tester.digsrc_skip_start :pin_or_group_name
+      #
+      def digsrc_skip_start(pin_or_group)
+        pin_or_group = dut.pin(pin_or_group).name
+        if @overlay_history[pin_or_group].nil?
+          @overlay_history[pin_or_group] = { count: 0, is_digsrc: true, start_applied: true }
+        else
+          Origen.log.warn 'tester.digsrc_skip_start must be called before any overlay actions on the pin'
+        end
+      end
+      
       # Perform digsrc overlay (called by tester.cycle)
       def digsrc_overlay(options = {})
         options[:overlay] = { change_data: true }.merge(options[:overlay])

--- a/pattern/tester_overlay_no_start.rb
+++ b/pattern/tester_overlay_no_start.rb
@@ -1,0 +1,41 @@
+Pattern.create(name: "test_overlay_no_start") do
+  tester.overlay_style = :digsrc
+  # increase coverage by changing tdi dig src settings
+  tester.source_memory :digsrc do |mem| 
+    mem.pin :tdi, size: 32
+  end
+  cc 'should get a repeat count added to this vector for digsrc start minimum distance'
+  tester.cycle
+  
+  dut.pin(:tclk).drive(1)
+  dut.pin(:tdi).drive(1)
+  dut.pin(:tdo).assert(1)
+  dut.pin(:tms).drive(1)
+  
+  cc 'should get a repeat 5 vector'
+  tester.cycle repeat: 5
+
+  tester.digsrc_skip_start :tdi_a if tester.ultraflex?
+  tester.digsrc_skip_start :pa if tester.ultraflex?
+  
+  cc 'should get a send microcode and 1 cycle with D'
+  tester.cycle overlay: {overlay_str: 'dummy_str', pins: dut.pin(:tdi_a)}
+  cc 'should get a cycle with D and no send'
+  tester.cycle overlay: {overlay_str: 'dummy_str', pins: dut.pin(:tdi_a), change_data: false}
+  cc 'regular cycle with no D or send'
+  tester.cycle
+  
+  cc 'cycle with 001 on pa'
+  dut.pin(:pa).drive!(1)
+  cc 'send microcode followed by DDD on pa'
+  dut.pin(:pa).drive(0)
+  tester.cycle overlay: {overlay_str: "dummy_str", pins: dut.pin(:pa)}
+  cc 'cycle with 001 on pa'
+  dut.pin(:pa).drive!(1)
+  cc 'send microcode, DDD on pa with repeat 5 (will send 5 sets of data)'
+  dut.pin(:pa).drive(0)
+  tester.cycle repeat: 5, overlay: {overlay_str: "dummy_str", pins: dut.pin(:pa)}
+  cc 'cycle with 001 on pa'
+  dut.pin(:pa).drive!(1)
+  
+end

--- a/templates/origen_guides/pattern/ultraflex.md.erb
+++ b/templates/origen_guides/pattern/ultraflex.md.erb
@@ -16,7 +16,7 @@ UltraFlex supports <code>:digsrc</code> as a <code>tester.overlay_style</code> s
 ~~~
 
 By default Origen will automatically place the digsrc start opcode at the beginning of the resulting pattern
-when overlay is used. In some cases (like when the pattern is used in a pattern set that has already started
+when <code>:digsrc</code> overlay is used. In some cases (like when the pattern is used in a pattern set that has already started
 the instrument in a previous pattern, or possibly in svm_patterns) this behavior is undesirable.
 
 The insertion of this start opcode can be disabled by placing the following code **before** any overlay operations

--- a/templates/origen_guides/pattern/ultraflex.md.erb
+++ b/templates/origen_guides/pattern/ultraflex.md.erb
@@ -7,4 +7,24 @@ automatically to any supported platform.
 There are no significant APIs in this category currently, therefore refer to the
 [Common Pattern API](<%= path "guides/pattern/common" %>) which can fully target the UltraFLEX.
 
+### DigSrc
+
+UltraFlex supports <code>:digsrc</code> as a <code>tester.overlay_style</code> set like this:
+
+~~~ruby
+  tester.overlay_style = :digsrc
+~~~
+
+By default Origen will automatically place the digsrc start opcode at the beginning of the resulting pattern
+when overlay is used. In some cases (like when the pattern is used in a pattern set that has already started
+the instrument in a previous pattern, or possibly in svm_patterns) this behavior is undesirable.
+
+The insertion of this start opcode can be disabled by placing the following code **before** any overlay operations
+for a given pin.
+
+~~~ruby
+  tester.digsrc_skip_start :pin_or_group_name if tester.ultraflex?
+  # Overlay operations can happen after this point
+~~~
+
 % end


### PR DESCRIPTION
There are a few rare scenarios when you don't want Origen to automatically insert the digsrc instrument start command. This PR provides a way to turn it off.