### PR TITLE
ac_tml and dc_tml conflict solution

### DIFF
--- a/lib/origen_testers/basic_test_setups.rb
+++ b/lib/origen_testers/basic_test_setups.rb
@@ -81,7 +81,7 @@ module OrigenTesters
         line = flow.test(ins, options)
         { test_instance: ins, flow_line: line, patset: pset }
       elsif tester.v93k?
-        tm = test_methods.ac_tml.ac_test.functional_test
+        tm = test_methods.ac_tml_native.ac_test.functional_test
         ts = test_suites.run(name, options)
         ts.test_method = tm
         ts.pattern = pattern

--- a/lib/origen_testers/smartest_based_tester/base/test_methods.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_methods.rb
@@ -7,8 +7,8 @@ module OrigenTesters
 
         require 'origen_testers/smartest_based_tester/base/test_methods/base_tml'
         require 'origen_testers/smartest_based_tester/base/test_methods/limits'
-        autoload :AcTml, 'origen_testers/smartest_based_tester/base/test_methods/ac_tml'
-        autoload :DcTml, 'origen_testers/smartest_based_tester/base/test_methods/dc_tml'
+        autoload :AcTmlNative, 'origen_testers/smartest_based_tester/base/test_methods/ac_tml'
+        autoload :DcTmlNative, 'origen_testers/smartest_based_tester/base/test_methods/dc_tml'
         autoload :CustomTml, 'origen_testers/smartest_based_tester/base/test_methods/custom_tml'
 
         attr_accessor :flow, :collection
@@ -34,13 +34,13 @@ module OrigenTesters
         end
 
         # Returns the AC test method library
-        def ac_tml
-          @ac_tml ||= AcTml.new(self)
+        def ac_tml_native
+          @ac_tml_native ||= AcTmlNative.new(self)
         end
 
         # Returns the DC test method library
-        def dc_tml
-          @dc_tml ||= DcTml.new(self)
+        def dc_tml_native
+          @dc_tml_native ||= DcTmlNative.new(self)
         end
 
         # Creates an accessor for custom test method libraries the first time they are called

--- a/lib/origen_testers/smartest_based_tester/base/test_methods/ac_tml.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_methods/ac_tml.rb
@@ -2,7 +2,7 @@ module OrigenTesters
   module SmartestBasedTester
     class Base
       class TestMethods
-        class AcTml < BaseTml
+        class AcTmlNative < BaseTml
           TEST_METHODS = {
             frequency_by_digital_capture: {
               class_name:           'Frequency_byDigitalCapture',
@@ -36,7 +36,7 @@ module OrigenTesters
           end
 
           def klass
-            'ac_tml.AcTest'
+            'ac_tml_native.AcTest'
           end
         end
       end

--- a/lib/origen_testers/smartest_based_tester/base/test_methods/dc_tml.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_methods/dc_tml.rb
@@ -2,7 +2,7 @@ module OrigenTesters
   module SmartestBasedTester
     class Base
       class TestMethods
-        class DcTml < BaseTml
+        class DcTmlNative < BaseTml
           TEST_METHODS = {
             continuity:        {
               pinlist:               [:string, '@'],
@@ -138,7 +138,7 @@ module OrigenTesters
           end
 
           def klass
-            'dc_tml.DcTest'
+            'dc_tml_native.DcTest'
           end
         end
       end

--- a/lib/origen_testers/test/interface.rb
+++ b/lib/origen_testers/test/interface.rb
@@ -63,7 +63,7 @@ module OrigenTesters
         elsif tester.v93k?
           block_loop(name, options) do |block, i|
             options[:number] = number + i if number && i
-            tm = test_methods.ac_tml.ac_test.functional_test
+            tm = test_methods.ac_tml_native.ac_test.functional_test
             ts = test_suites.run(name, options)
             ts.test_method = tm
             if tester.smt8?
@@ -95,7 +95,7 @@ module OrigenTesters
 
           block_loop(name, options) do |block, i|
             options[:number] = number + i if number && i
-            tm = test_methods.ac_tml.ac_test.functional_test
+            tm = test_methods.ac_tml_native.ac_test.functional_test
             ts = test_suites.run(name, options)
             ts.test_method = tm
             ts.levels = options.delete(:pin_levels) if options[:pin_levels]
@@ -247,7 +247,7 @@ module OrigenTesters
           end
 
         elsif tester.v93k?
-          tm = test_methods.dc_tml.dc_test.general_pmu
+          tm = test_methods.dc_tml_native.dc_test.general_pmu
           ts = test_suites.run(name, options)
           ts.test_method = tm
           if tester.smt8?


### PR DESCRIPTION
Hi,

The issue is due to origen_testers having native dc_tml and ac_tml test method libraries that are named the same as the Advantest libraries.  The origen_testers test methods do not match the Advantest test method parameters, preventing users from programming certain test method parameters.  For example in DcTml.Continuity:

origen_testers:

~~~ruby
            continuity:        {
              pinlist:               [:string, '@'],
              test_current:          [:current, 10.uA],
              settling_time:         [:time, 1.ms],
              measurement_mode:      [:string, 'PPMUpar', %w(PPMUpar ProgLoad)],
              polarity:              [:string, 'SPOL', ['SPOL' 'BPOL']],
              precharge_to_zero_vol: [:string, 'ON', %w(ON OFF)],
              test_name:             [:string, 'passVolt_mv'],
              output:                [:string, 'None', %w(None ReportUI ShowFailOnly)]
            },
~~~

Advantest (parsed from ASCII file created by tmm_console utility):

~~~ruby
 "result0"=>[:double, ""],
 "result1"=>[:double, ""],
 "result2"=>[:double, ""],
 "result3"=>[:double, ""],
 "pinlist"=>[:string, ""],
 "testCurrent"=>[:string, ""],
 "settlingTime"=>[:string, ""],
 "measurementMode"=>[:string, ""],
 "polarity"=>[:string, ""],
 "prechargeToZeroVol"=>[:string, ""],
 "testName"=>[:string, ""],
 "output"=>[:string, ""]}
~~~



