### PR TITLE
added program comment char to SMT testers

### DIFF
--- a/lib/origen_testers/origen_ext/generator/flow.rb
+++ b/lib/origen_testers/origen_ext/generator/flow.rb
@@ -183,6 +183,85 @@ module Origen
         [flow_comments, comments]
       end
 
+      def header
+        Origen.tester.pre_header if Origen.tester.doc?
+        inject_separator
+        if $desc
+          c2 'DESCRIPTION:'
+          $desc.split(/\n/).each { |line| cc line }
+          inject_separator
+        end
+        c2 'GENERATED:'
+        c2 "  Time:    #{Origen.launch_time}"
+        c2 "  By:      #{Origen.current_user.name}"
+        c2 "  Mode:    #{Origen.mode}"
+        binding.pry
+        l = "  Command: origen p #{job.requested_pattern} -t #{Origen.target.file.basename}"
+        if Origen.environment && Origen.environment.file
+          l += " -e #{Origen.environment.file.basename}"
+        end
+        c2(l)
+        inject_separator
+        c2 'ENVIRONMENT:'
+        c2 '  Origen'
+        c2 '    Source:    https://github.com/Origen-SDK/origen'
+        c2 "    Version:   #{Origen.version}"
+        unless Origen.app.plugins.empty?
+          c2 '  Plugins'
+          Origen.app.plugins.sort_by { |p| p.name.to_s }.each do |plugin|
+            c2 "    #{plugin.name}:".ljust(30) + plugin.version
+          end
+        end
+        inject_separator
+
+        unless Origen.app.plugins.empty?
+          # Plugins can use config.shared_flow_header to inject plugin-specific comments into the flow header
+          header_printed = false
+          Origen.app.plugins.sort_by { |p| p.name.to_s }.each do |plugin|
+            unless plugin.config.shared_flow_header.nil?
+              unless header_printed
+                c2 'Header Comments From Shared Plugins:'
+                header_printed = true
+              end
+              inject_flow_header(
+                config_loc:      plugin,
+                scope:           :shared_flow_header,
+                message:         "Header Comments From Shared Plugin: #{plugin.name}:",
+                message_spacing: 2,
+                line_spacing:    4,
+                no_separator:    true
+              )
+            end
+          end
+          inject_separator if header_printed
+        end
+
+        if Origen.app.plugins.current && !Origen.app.plugins.current.config.send(:current_plugin_flow_header).nil?
+          # The top level plugin (if one is set) can further inject plugin-specific comment into the header.
+          # These will only appear if the plugin is the top-level plugin though.
+          inject_flow_header(
+            config_loc: Origen.app.plugins.current,
+            scope:      :current_plugin_flow_header,
+            message:    "Header Comments From The Current Plugin: #{Origen.app.plugins.current.name}:"
+          )
+        end
+
+        unless Origen.app.config.send(:application_flow_header).nil?
+          inject_flow_header(
+            config_loc: Origen.app,
+            scope:      :application_flow_header,
+            message:    "Header Comments From Application: #{Origen.app.name}:"
+          )
+        end
+
+        if Origen.config.flow_header
+          Origen.log.deprecated 'Origen.config.flow_header is deprecated.'
+          Origen.log.deprecated 'Please use config.shared_flow_header, config.application_flow_header, or config.current_plugin_flow_header instead.'
+          inject_separator
+        end
+        Origen.tester.close_text_block if Origen.tester.doc?
+      end
+
       private
 
       def reload_target?(interface, options)
@@ -200,6 +279,7 @@ module Origen
           false
         end
       end
+
     end
   end
 

--- a/lib/origen_testers/smartest_based_tester/base.rb
+++ b/lib/origen_testers/smartest_based_tester/base.rb
@@ -70,6 +70,9 @@ module OrigenTesters
       # format (SMT8 only)
       attr_accessor :zip_patterns
 
+      # Program comment character that affects what portions of a gnerated flow file to ignore during diff
+      attr_reader :program_comment_char
+
       def initialize(options = {})
         options = {
           # whether to use multiport bursts or not, if so this indicates the name of the port to use
@@ -99,8 +102,10 @@ module OrigenTesters
         @min_repeat_loop = 33
         if smt8?
           @pat_extension = 'pat'
+          @program_comment_char = '//'
         else
           @pat_extension = 'avc'
+          @program_comment_char = '--'
         end
         @compress = true
         # @support_repeat_previous = true

--- a/lib/origen_testers/smartest_based_tester/v93k/templates/template.tf.erb
+++ b/lib/origen_testers/smartest_based_tester/v93k/templates/template.tf.erb
@@ -1,3 +1,5 @@
+<%= Origen.generator.flow.header %>
+
 hp93000,testflow,0.1
 language_revision = 1;
 

--- a/spec/testers_spec.rb
+++ b/spec/testers_spec.rb
@@ -22,4 +22,17 @@ describe "IGXL Based Tester class" do
     $tester.name.should == "ultraflex"
   end
 
+  it "select SmartTest SMT7 tester properly" do
+    Origen.environment.temporary = "v93k.rb"
+    Origen.load_target("dut.rb")
+    $tester.name.should == "v93k"
+    $tester.program_comment_char == '--'
+  end
+
+  it "select SmartTest SMT8 tester properly" do
+    Origen.environment.temporary = "v93k_smt8.rb"
+    Origen.load_target("dut.rb")
+    $tester.name.should == "v93k"
+    $tester.program_comment_char == '//'
+  end
 end


### PR DESCRIPTION
This PR should force the flow file diff to ignore the proper comment characters for SMT7 and SMT8.  Not sure if I can test this fully as the diff code is in the origen core.  Any ideas on testing this?