### PR TITLE
Adding IGXL node to permit  moving any device conditions on a flow line to a group condition

### DIFF
--- a/lib/origen_testers/atp/flow.rb
+++ b/lib/origen_testers/atp/flow.rb
@@ -419,6 +419,10 @@ module OrigenTesters::ATP
             end
           end
 
+          if options[:igxl]
+            children << n1(:igxl, options[:igxl])
+          end
+
           if before_on_fail
             on_fail_node = on_fail(before_on_fail)
             if options[:on_fail]

--- a/lib/origen_testers/igxl_based_tester/base/flow.rb
+++ b/lib/origen_testers/igxl_based_tester/base/flow.rb
@@ -75,8 +75,25 @@ module OrigenTesters
           process_all(nodes)
         end
 
+        # Returns any IG-XL hash embedded in the given node, or nil if there is none
+        def igxl(node)
+          igxl = node.find(:igxl)
+          igxl.to_a[0] if igxl
+        end
+
         def on_test(node)
           line = new_line(:test) { |l| process_all(node) }
+
+          # Move any device conditions on this line to a group condition instead
+          if options = igxl(node)
+            if options[:change_device_condition_to_group]
+              line.group_condition = line.device_condition
+              line.device_condition = nil
+              line.group_name = line.device_name
+              line.device_name = nil
+              line.group_specifier = 'any-active'
+            end
+          end
 
           # In IG-XL you can't set the same flag in case of pass or fail, that situation should
           # never occur unless the user has manually set up that condition


### PR DESCRIPTION
@ThaoHuynhFsl has asked me to make a change for one of the project he's worked on before.  

The change is to add an igxl node to permit flows to take advantage of the group conditions instead of just the device conditional.

Not sure if this will fly or not, given that it's a tester-specific thing.  Want to see how the team wants to properly handle it.

--Daniel