### PR TITLE
fixed a corner case bug that causes the generator to hang

### DIFF
--- a/lib/origen_testers/labview_based_tester/pxie6570.rb
+++ b/lib/origen_testers/labview_based_tester/pxie6570.rb
@@ -36,7 +36,7 @@ module OrigenTesters
         unless options[:subroutine_pat]
           stage.with_bank(:body) do
             # find the first vector
-            stage.bank.delete_at(0) until stage.bank[0].is_a?(OrigenTesters::Vector)
+            stage.bank.delete_at(0) until stage.bank[0].is_a?(OrigenTesters::Vector) || stage.bank.empty?
           end
         end
       end


### PR DESCRIPTION
In the case where a pattern is created but no cycles are generated, the header method would hang. Not something you'd normally expect to be done. But, in the case where you're taking advantage of the 64 cycle minimum cycle count, you can still get a valid pattern without ever generating a cycle.