### PR TITLE
Prevent test number duplication (violates STDF standards)

### DIFF
--- a/approved/ultraflex/prb1_flow.txt
+++ b/approved/ultraflex/prb1_flow.txt
@@ -123,11 +123,11 @@ DTFlowtableSheet,version=2.2:platform=Jaguar:toprow=-1:leftcol=-1:rightcol=-1	Fl
 						logprint	Verify_that_MTO_template_works...																										
 						logprint	import_statement																										
 						Test	bgap_voltage_meas	bgap_voltage_meas	5810							119		2	Fail														
-						Use-Limit		bgap_voltage_meas	5810		45					119		2	Fail														
+						Use-Limit		bgap_voltage_meas			45					119		2	Fail														
 						Test	bgap_voltage_meas1	bgap_voltage_meas1	5820										Fail														
 						logprint	direct_call																										
 						Test	bgap_voltage_meas	bgap_voltage_meas	5910							119		2	Fail														
-						Use-Limit		bgap_voltage_meas	5910		45					119		2	Fail														
+						Use-Limit		bgap_voltage_meas			45					119		2	Fail														
 						Test	bgap_voltage_meas1	bgap_voltage_meas1	5920										Fail														
 						logprint	Speed_binning_example_bug_from_video_5																										
 						Test	test200_1		5950										None		g200_7AF57D1_FAILED_0												
@@ -164,28 +164,28 @@ DTFlowtableSheet,version=2.2:platform=Jaguar:toprow=-1:leftcol=-1:rightcol=-1	Fl
 						Test	cc_test_2	cc_test_2	7002										Fail														
 						Test	deep_test												None		deep_test_7AF57D1_FAILED												
 						Test	meas_read_pump	meas_read_pump	40005							119		2	Fail														
-						Use-Limit		meas_read_pump	40005	35						119		2	Fail														
+						Use-Limit		meas_read_pump		35						119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40010							119		2	Fail														
-						Use-Limit		meas_read_pump	40010		45					119		2	Fail														
+						Use-Limit		meas_read_pump			45					119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40020							119		2	Fail														
-						Use-Limit		meas_read_pump	40020	35	45					119		2	Fail														
+						Use-Limit		meas_read_pump		35	45					119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40030							119		2	Fail														
-						Use-Limit		meas_read_pump	40030	35	45					119		2	Fail														
+						Use-Limit		meas_read_pump		35	45					119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40040							119		2	Fail														
-						Use-Limit		meas_read_pump	40040	0.035	0.045					119		2	Fail														
+						Use-Limit		meas_read_pump		0.035	0.045					119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40050							119		2	None														
-						Use-Limit		meas_read_pump	40050	0.035	0.045					119		2	None														
+						Use-Limit		meas_read_pump		0.035	0.045					119		2	None														
 						Test	meas_read_pump	meas_read_pump	40060							119		2	None														
-						Use-Limit		meas_read_pump	40060	0.01	2000					119		2	None														
+						Use-Limit		meas_read_pump		0.01	2000					119		2	None														
 						Test	meas_read_pump	meas_read_pump	40070							119		2	None														
-						Use-Limit		meas_read_pump	40070	0.01	_some_spec					119		2	None														
+						Use-Limit		meas_read_pump		0.01	_some_spec					119		2	None														
 						Test	meas_read_pump	meas_read_pump	40080							119		2	Fail														
-						Use-Limit		meas_read_pump	40080		1					119		2	Fail														
-						Use-Limit		meas_read_pump	40080		2					119		2	Fail														
+						Use-Limit		meas_read_pump			1					119		2	Fail														
+						Use-Limit		meas_read_pump			2					119		2	Fail														
 						Test-defer-limits	meas_read_pump	meas_read_pump	40090							119		2	Fail														
-						Use-Limit		meas_read_pump	40090	1.0e-06	4.0e-06		A			119		2	Fail														
-						Use-Limit		meas_read_pump	40090	2.0e-06	5.0e-06		A			119		2	Fail														
-						Use-Limit		meas_read_pump	40090	3.0e-06			A			119		2	Fail														
+						Use-Limit		meas_read_pump		1.0e-06	4.0e-06		A			119		2	Fail														
+						Use-Limit		meas_read_pump		2.0e-06	5.0e-06		A			119		2	Fail														
+						Use-Limit		meas_read_pump		3.0e-06			A			119		2	Fail														
 						Test	measmulti_bin_now	measmulti_bin_now	3000							119		2	Fail														
 						Use-Limit	measmulti_bin_now	limit1	3001	0	7					119		2	Fail														
 						Use-Limit	measmulti_bin_now	limit2	3002	3	8					119		2	Fail														

--- a/approved/ultraflex/test_flow.txt
+++ b/approved/ultraflex/test_flow.txt
@@ -3,28 +3,28 @@ DTFlowtableSheet,version=2.2:platform=Jaguar:toprow=-1:leftcol=-1:rightcol=-1	Fl
 			Gate			Command				Limits		Datalog Display Results			Bin Number		Sort Number			Flag			Group				Device			Debug			
 	Label	Enable	Job	Part	Env	Opcode	Parameter	TName	TNum	LoLim	HiLim	Scale	Units	Format	Pass	Fail	Pass	Fail	Result	Pass	Fail	State	Specifier	Sense	Condition	Name	Sense	Condition	Name	Assume	Sites	Comment	
 						Test	meas_read_pump	meas_read_pump	40005							119		2	Fail														
-						Use-Limit		meas_read_pump	40005	35						119		2	Fail														
+						Use-Limit		meas_read_pump		35						119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40010							119		2	Fail														
-						Use-Limit		meas_read_pump	40010		45					119		2	Fail														
+						Use-Limit		meas_read_pump			45					119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40020							119		2	Fail														
-						Use-Limit		meas_read_pump	40020	35	45					119		2	Fail														
+						Use-Limit		meas_read_pump		35	45					119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40030							119		2	Fail														
-						Use-Limit		meas_read_pump	40030	35	45					119		2	Fail														
+						Use-Limit		meas_read_pump		35	45					119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40040							119		2	Fail														
-						Use-Limit		meas_read_pump	40040	0.035	0.045					119		2	Fail														
+						Use-Limit		meas_read_pump		0.035	0.045					119		2	Fail														
 						Test	meas_read_pump	meas_read_pump	40050							119		2	None														
-						Use-Limit		meas_read_pump	40050	0.035	0.045					119		2	None														
+						Use-Limit		meas_read_pump		0.035	0.045					119		2	None														
 						Test	meas_read_pump	meas_read_pump	40060							119		2	None														
-						Use-Limit		meas_read_pump	40060	0.01	2000					119		2	None														
+						Use-Limit		meas_read_pump		0.01	2000					119		2	None														
 						Test	meas_read_pump	meas_read_pump	40070							119		2	None														
-						Use-Limit		meas_read_pump	40070	0.01	_some_spec					119		2	None														
+						Use-Limit		meas_read_pump		0.01	_some_spec					119		2	None														
 						Test	meas_read_pump	meas_read_pump	40080							119		2	Fail														
-						Use-Limit		meas_read_pump	40080		1					119		2	Fail														
-						Use-Limit		meas_read_pump	40080		2					119		2	Fail														
+						Use-Limit		meas_read_pump			1					119		2	Fail														
+						Use-Limit		meas_read_pump			2					119		2	Fail														
 						Test-defer-limits	meas_read_pump	meas_read_pump	40090							119		2	Fail														
-						Use-Limit		meas_read_pump	40090	1.0e-06	4.0e-06		A			119		2	Fail														
-						Use-Limit		meas_read_pump	40090	2.0e-06	5.0e-06		A			119		2	Fail														
-						Use-Limit		meas_read_pump	40090	3.0e-06			A			119		2	Fail														
+						Use-Limit		meas_read_pump		1.0e-06	4.0e-06		A			119		2	Fail														
+						Use-Limit		meas_read_pump		2.0e-06	5.0e-06		A			119		2	Fail														
+						Use-Limit		meas_read_pump		3.0e-06			A			119		2	Fail														
 						Test	measmulti_bin_now	measmulti_bin_now	3000							119		2	Fail														
 						Use-Limit	measmulti_bin_now	limit1	3001	0	7					119		2	Fail														
 						Use-Limit	measmulti_bin_now	limit2	3002	3	8					119		2	Fail														

--- a/lib/origen_testers/igxl_based_tester/ultraflex/flow.rb
+++ b/lib/origen_testers/igxl_based_tester/ultraflex/flow.rb
@@ -23,6 +23,7 @@ module OrigenTesters
             limit.type = :use_limit
             limit.opcode = 'Use-Limit'
             limit.parameter = nil
+            limit.tnum = nil                            # Don't duplate test numbers, allow auto-increment by leaving blank
             if ins.respond_to?(:lo_limit)
               lo = ins.lo_limit
               hi = ins.hi_limit


### PR DESCRIPTION
This change was requested to bring an existing app up to STDF standards compliance. It does open the possibility of creating a scenario where the auto-incremented test numbers over run the test number for a subsequent test. Either case the duplicated test numbers are not allowed and cause issues with STDF output.

The other option for correcting the test numbers in an app is to use sub tests to create use-limit lines. In this case the app can define the tnum or leave it blank.