### PR TITLE
get unfrozen string before modifying

### DIFF
--- a/approved/j750/flow_control_flag_bug_flow.txt
+++ b/approved/j750/flow_control_flag_bug_flow.txt
@@ -1,0 +1,15 @@
+DFF 1.1	Flow Table																											
+																												
+			Gate			Command				Bin Number		Sort Number			Flag			Group				Device			Debug			
+	Label	Enable	Job	Part	Env	Opcode	Parameter	TName	TNum	Pass	Fail	Pass	Fail	Result	Pass	Fail	State	Specifier	Sense	Condition	Name	Sense	Condition	Name	Assume	Sites	Comment	
+						logprint	Mixed-case_manual_flags																					
+						Test	test1		51420					None		My_Mixed_Flag_0												
+						defaults										My_Mixed_Flag												
+						flag-true	My_Mixed_Flag																flag-true	My_Mixed_Flag_0				
+						Test	test2		51430					Fail									flag-true	My_Mixed_Flag				
+						Test	test3		51440					Fail								not	flag-true	My_Mixed_Flag				
+						logprint	Mixed-case_manual_flags_-_induce_frozen_string_error																					
+						Test	test4		51450					None		My_Mixed_Flag_1												
+						flag-true	My_Mixed_Flag																flag-true	My_Mixed_Flag_1				
+						Test	test5		51460					Fail									flag-true	My_Mixed_Flag				
+						Test	test6		51470					Fail								not	flag-true	My_Mixed_Flag				

--- a/approved/j750_hpt/flow_control_flag_bug_flow.txt
+++ b/approved/j750_hpt/flow_control_flag_bug_flow.txt
@@ -1,0 +1,15 @@
+DFF 1.1	Flow Table																											
+																												
+			Gate			Command				Bin Number		Sort Number			Flag			Group				Device			Debug			
+	Label	Enable	Job	Part	Env	Opcode	Parameter	TName	TNum	Pass	Fail	Pass	Fail	Result	Pass	Fail	State	Specifier	Sense	Condition	Name	Sense	Condition	Name	Assume	Sites	Comment	
+						logprint	Mixed-case_manual_flags																					
+						Test	test1		51420					None		My_Mixed_Flag_0												
+						defaults										My_Mixed_Flag												
+						flag-true	My_Mixed_Flag																flag-true	My_Mixed_Flag_0				
+						Test	test2		51430					Fail									flag-true	My_Mixed_Flag				
+						Test	test3		51440					Fail								not	flag-true	My_Mixed_Flag				
+						logprint	Mixed-case_manual_flags_-_induce_frozen_string_error																					
+						Test	test4		51450					None		My_Mixed_Flag_1												
+						flag-true	My_Mixed_Flag																flag-true	My_Mixed_Flag_1				
+						Test	test5		51460					Fail									flag-true	My_Mixed_Flag				
+						Test	test6		51470					Fail								not	flag-true	My_Mixed_Flag				

--- a/approved/ultraflex/Jobs.txt
+++ b/approved/ultraflex/Jobs.txt
@@ -2,5 +2,5 @@ DTJobListSheet,version=2.5:platform=Jaguar:toprow=-1:leftcol=-1:rightcol=-1	Job 
 
 		Sheet Parameters	
 	Job Name	Pin Map	Test Instances	Flow Table	AC Specs	DC Specs	Pattern Sets	Pattern Groups	Bin Table	Characterization	Test Procedures	Mixed Signal Timing	Wave Definitions	Psets	Signals	Port Map	Fractional Bus	Concurrent Sequence	Comment
-	FT	pinmap_test	prb1_instances,prb2_instances,global_instances,flow_control_instances	prb1_flow,prb2_flow,test_flow,flow_control_flow,basic_interface_flow,custom_tests_flow	SpecsAC_func	SpecsDC_func	prb1_patsets,prb2_patsets,global_patsets,flow_control_patsets											
+	FT	pinmap_test	prb1_instances,prb2_instances,global_instances,flow_control_instances	prb1_flow,prb2_flow,test_flow,flow_control_flow,flow_control_flag_bug_flow,basic_interface_flow,custom_tests_flow	SpecsAC_func	SpecsDC_func	prb1_patsets,prb2_patsets,global_patsets,flow_control_patsets											
 	WT	pinmap_test	prb1_instances,prb2_instances,global_instances,flow_control_instances	WT_flow1,WT_flow2	SpecsAC_func	SpecsDC_func	prb1_patsets,prb2_patsets,global_patsets,flow_control_patsets											

--- a/approved/ultraflex/flow_control_flag_bug_flow.txt
+++ b/approved/ultraflex/flow_control_flag_bug_flow.txt
@@ -1,0 +1,15 @@
+DTFlowtableSheet,version=2.2:platform=Jaguar:toprow=-1:leftcol=-1:rightcol=-1	Flow Table																																
+						Flow Domain:																											
+			Gate			Command				Limits		Datalog Display Results			Bin Number		Sort Number			Flag			Group				Device			Debug			
+	Label	Enable	Job	Part	Env	Opcode	Parameter	TName	TNum	LoLim	HiLim	Scale	Units	Format	Pass	Fail	Pass	Fail	Result	Pass	Fail	State	Specifier	Sense	Condition	Name	Sense	Condition	Name	Assume	Sites	Comment	
+						logprint	Mixed-case_manual_flags																										
+						Test	test1		51420										None		My_Mixed_Flag_0												
+						defaults															My_Mixed_Flag												
+						flag-true	My_Mixed_Flag																					flag-true	My_Mixed_Flag_0				
+						Test	test2		51430										Fail									flag-true	My_Mixed_Flag				
+						Test	test3		51440										Fail								not	flag-true	My_Mixed_Flag				
+						logprint	Mixed-case_manual_flags_-_induce_frozen_string_error																										
+						Test	test4		51450										None		My_Mixed_Flag_1												
+						flag-true	My_Mixed_Flag																					flag-true	My_Mixed_Flag_1				
+						Test	test5		51460										Fail									flag-true	My_Mixed_Flag				
+						Test	test6		51470										Fail								not	flag-true	My_Mixed_Flag				

--- a/approved/v93k/testflow/mfh.testflow.group/flow_control_flag_bug.tf
+++ b/approved/v93k/testflow/mfh.testflow.group/flow_control_flag_bug.tf
@@ -1,0 +1,72 @@
+hp93000,testflow,0.1
+language_revision = 1;
+
+testmethodparameters
+end
+-----------------------------------------------------------------
+testmethodlimits
+end
+-----------------------------------------------------------------
+test_flow
+
+  {
+    {
+       @My_Mixed_Flag = -1;
+    }, open,"Init Flow Control Vars", ""
+    print_dl("Mixed-case manual flags");
+    run_and_branch(test1)
+    then
+    {
+    }
+    else
+    {
+       @My_Mixed_Flag = 1;
+    }
+    if @My_Mixed_Flag == 1 then
+    {
+       run(test2);
+    }
+    else
+    {
+       run(test3);
+    }
+    print_dl("Mixed-case manual flags - induce frozen string error");
+    run_and_branch(test4)
+    then
+    {
+    }
+    else
+    {
+       @My_Mixed_Flag = 1;
+    }
+    if @My_Mixed_Flag == 1 then
+    {
+       run(test5);
+    }
+    else
+    {
+       run(test6);
+    }
+
+  }, open,"Flow Control Testing","Flow to exercise the Flow Control API"
+
+end
+-----------------------------------------------------------------
+binning
+end
+-----------------------------------------------------------------
+oocrule
+
+
+end
+-----------------------------------------------------------------
+context
+
+
+end
+-----------------------------------------------------------------
+hardware_bin_descriptions
+
+
+end
+-----------------------------------------------------------------

--- a/approved/v93k_smt8/OrigenTesters/flows/FLOW_CONTROL_FLAG_BUG.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/FLOW_CONTROL_FLAG_BUG.flow
@@ -1,0 +1,32 @@
+flow FLOW_CONTROL_FLAG_BUG {
+
+    out My_Mixed_Flag = -1;
+
+    setup {
+    }
+
+    execute {
+        My_Mixed_Flag = -1;
+
+        println("Mixed-case manual flags");
+        test1.execute();
+        if (!test1.pass) {
+            My_Mixed_Flag = 1;
+        }
+        if (My_Mixed_Flag == 1) {
+            test2.execute();
+        } else {
+            test3.execute();
+        }
+        println("Mixed-case manual flags - induce frozen string error");
+        test4.execute();
+        if (!test4.pass) {
+            My_Mixed_Flag = 1;
+        }
+        if (My_Mixed_Flag == 1) {
+            test5.execute();
+        } else {
+            test6.execute();
+        }
+    }
+}

--- a/approved/v93k_smt8/OrigenTesters/limits/Main.FLOW_CONTROL_FLAG_BUG_Tests.csv
+++ b/approved/v93k_smt8/OrigenTesters/limits/Main.FLOW_CONTROL_FLAG_BUG_Tests.csv
@@ -1,0 +1,8 @@
+Test Suite,Test,Test Number,Test Text,Low Limit,High Limit,Unit,Soft Bin
+,,,,default,default
+test1,test1,51420,test1,0,0,,
+test2,test2,51430,test2,0,0,,
+test3,test3,51440,test3,0,0,,
+test4,test4,51450,test4,0,0,,
+test5,test5,51460,test5,0,0,,
+test6,test6,51470,test6,0,0,,

--- a/lib/origen_testers/igxl_based_tester/base/flow.rb
+++ b/lib/origen_testers/igxl_based_tester/base/flow.rb
@@ -430,7 +430,8 @@ module OrigenTesters
         end
 
         def clean_flag(flag)
-          flag = flag.to_s
+          # Added .dup to below line to get an unfrozen copy of the string, corrects a run time error
+          flag = flag.to_s.dup
           if flag[0] == '$'
             flag[0] = ''
           end

--- a/program/flow_control_flag_bug.rb
+++ b/program/flow_control_flag_bug.rb
@@ -1,0 +1,25 @@
+# Flow to exercise the Flow Control API
+#
+# Some of the other flows also cover the flow control API and those tests are used
+# to guarantee that the test ID references work when sub-flows are involved.
+# This flow provides a full checkout of all flow control methods.
+Flow.create interface: 'OrigenTesters::Test::Interface', flow_name: "Flow Control Testing" do
+  flow.flow_description = 'Flow to exercise the Flow Control API' if tester.v93k?
+
+  self.resources_filename = 'flow_control'
+
+  log "Mixed-case manual flags"
+  test :test1, on_fail: { set_flag: :$My_Mixed_Flag }, continue: true, number: 51420
+  test :test2, if_flag: "$My_Mixed_Flag", number: 51430
+  unless_flag "$My_Mixed_Flag" do
+    test :test3, number: 51440
+  end
+  
+  log "Mixed-case manual flags - induce frozen string error"
+  test :test4, on_fail: { set_flag: :$My_Mixed_Flag }, continue: true, number: 51450
+  test :test5, if_flag: "$My_Mixed_Flag", number: 51460
+  unless_flag "$My_Mixed_Flag" do
+    test :test6, number: 51470
+  end
+
+end

--- a/program/prod.list
+++ b/program/prod.list
@@ -4,5 +4,6 @@ prb1_resources.rb
 prb2.rb
 test.rb
 flow_control.rb
+flow_control_flag_bug.rb
 basic_interface.rb
 custom_tests.rb


### PR DESCRIPTION
I was unable to create a case to duplicate the error. But, there is a case where the object passed to <code>clean_flag</code> is frozen (immutable). The string created by <code>to_s</code> will also be frozen in that case. The <code>.dup</code> method returns a mutable copy of the string.