### PR TITLE
ADD program comment chars for SMT7/8

### DIFF
--- a/lib/origen_testers/api.rb
+++ b/lib/origen_testers/api.rb
@@ -11,6 +11,7 @@ module OrigenTesters
     attr_accessor :includes
     attr_accessor :comment_level
     attr_accessor :generating
+
     # Get/Set the overlay style
     #
     # This method changes the way overlay is handled.
@@ -19,6 +20,7 @@ module OrigenTesters
     # @example
     #   tester.overlay_style = :label
     attr_accessor :overlay_style
+
     # Get/Set the capture style
     #
     # This method changes the way tester.store() implements the store
@@ -49,8 +51,16 @@ module OrigenTesters
     end
     alias_method :pattern_extension, :pat_extension
 
+    def comment_char=(val)
+      @comment_char = val
+    end
+
     def comment_char
       @comment_char || '//'
+    end
+
+    def program_comment_char=(val)
+      @program_comment_char = val
     end
 
     def program_comment_char

--- a/lib/origen_testers/smartest_based_tester/base.rb
+++ b/lib/origen_testers/smartest_based_tester/base.rb
@@ -99,15 +99,16 @@ module OrigenTesters
         @min_repeat_loop = 33
         if smt8?
           @pat_extension = 'pat'
+          @program_comment_char = ['println', '//']
         else
           @pat_extension = 'avc'
+          @program_comment_char = ['print_dl', '//']
         end
         @compress = true
         # @support_repeat_previous = true
         @match_entries = 10
         @name = 'v93k'
         @comment_char = '#'
-        @program_comment_char = ['print_dl', '//']
         @level_period = true
         @inline_comments = true
         @multiport = options[:multiport]

--- a/lib/origen_testers/smartest_based_tester/base.rb
+++ b/lib/origen_testers/smartest_based_tester/base.rb
@@ -107,7 +107,7 @@ module OrigenTesters
         @match_entries = 10
         @name = 'v93k'
         @comment_char = '#'
-        @program_comment_char = ['print_dl', "//"]
+        @program_comment_char = ['print_dl', '//']
         @level_period = true
         @inline_comments = true
         @multiport = options[:multiport]
@@ -466,7 +466,6 @@ module OrigenTesters
         # Ensure the match pins are don't care by default
         pin.dont_care
         options[:pin2].dont_care if options[:pin2]
-
         if !options[:pin2]
           cc "for the #{pin.name.upcase} pin to go #{state.to_s.upcase}"
           match_block(timeout_in_cycles, options) do |match_or_conditions, fail_conditions|

--- a/lib/origen_testers/smartest_based_tester/base.rb
+++ b/lib/origen_testers/smartest_based_tester/base.rb
@@ -107,6 +107,7 @@ module OrigenTesters
         @match_entries = 10
         @name = 'v93k'
         @comment_char = '#'
+        @program_comment_char = ['print_dl', "//"]
         @level_period = true
         @inline_comments = true
         @multiport = options[:multiport]

--- a/program/prb1.rb
+++ b/program/prb1.rb
@@ -8,6 +8,10 @@ Flow.create interface: 'OrigenTesters::Test::Interface', flow_description: 'Prob
     self.resources_filename = 'prb1'
   end
 
+  # Extra log below not in approved/ folder to show that comments are 
+  # being skipped correctly during the difference checks
+  log 'PRB1 Test Flow Version 00001 - do not copy me to approved!'
+
   import 'components/prb1_main'
 
   import 'test' # import top-level test.rb directly, note that Flow.create options of sub-flow will be ignored!


### PR DESCRIPTION
C or Java code program comment char not set properly for SMT7/8 test programs.  Since was not set would default to `#` which would make having built-in Origen diffs not be able to skip those comments in that code.

Have added `program_comment_char` for Smartest_based testers.

Also added ability for user to modify the `comment_char`or `program_comment_char` for any tester -- in case a strange case comes up in the future.