### PR TITLE
Feature/ruby 31 wip

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -19,9 +19,6 @@ jobs:
       run: echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
     - name: Install Bundler
       run: gem install bundler -v '> 2'
-    # temporarily deleting Gemfile.lock
-    - name: Delete Gemfile.lock
-      run: rm Gemfile.lock
     - name: Install dependencies
       run: bundle install  
     - name: Gem Install Origen 

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -19,6 +19,9 @@ jobs:
       run: echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
     - name: Install Bundler
       run: gem install bundler -v '> 2'
+    # temporarily deleting Gemfile.lock
+    - name: Delete Gemfile.lock
+      run: rm Gemfile.lock
     - name: Install dependencies
       run: bundle install  
     - name: Gem Install Origen 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       origen_stil (>= 0.2.1)
       require_all (~> 1)
       rodf (~> 1)
-      sexpistol (~> 0.0)
+      sexpistol (= 0.0.7)
       simplecov (~> 0.17)
       simplecov-html (~> 0.10.0)
 
@@ -146,7 +146,7 @@ GEM
     ruby-progressbar (1.11.0)
     rubyzip (1.3.0)
     scrub_rb (1.0.1)
-    sexpistol (0.1.2)
+    sexpistol (0.0.7)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)

--- a/approved/v93k_smt8/OrigenTesters/flows/CUSTOM_TESTS.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/CUSTOM_TESTS.flow
@@ -1,9 +1,9 @@
 flow CUSTOM_TESTS {
 
+
     setup {
     }
 
     execute {
-
     }
 }

--- a/approved/v93k_smt8/OrigenTesters/flows/flow_control/SMALL.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/flow_control/SMALL.flow
@@ -6,7 +6,6 @@ flow SMALL {
     }
 
     execute {
-
         if (SMALL_FLOW == 1) {
             test1.execute();
             test2.execute();

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/prb1_main/ADDITIONAL_ERASE.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/prb1_main/ADDITIONAL_ERASE.flow
@@ -13,7 +13,6 @@ flow ADDITIONAL_ERASE {
     }
 
     execute {
-
         if (ADDITIONAL_ERASE == 1) {
             erase_all.execute();
         } else {

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/prb1_main/ADDITIONAL_ERASE_1.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/prb1_main/ADDITIONAL_ERASE_1.flow
@@ -1,5 +1,6 @@
 flow ADDITIONAL_ERASE_1 {
 
+
     setup {
         suite erase_all calls ac_tml.AcTest.FunctionalTest {
             measurement.pattern = setupRef(OrigenTesters.patterns.erase_all);
@@ -11,7 +12,6 @@ flow ADDITIONAL_ERASE_1 {
     }
 
     execute {
-
         erase_all.execute();
     }
 }

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/prb1_main/ERASE.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/prb1_main/ERASE.flow
@@ -49,7 +49,6 @@ flow ERASE {
     }
 
     execute {
-
         erase_all.execute();
         erase_all_1.execute();
         erase_all_2.execute();

--- a/approved/v93k_smt8/OrigenTesters/flows/prb2/PRB2_MAIN.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb2/PRB2_MAIN.flow
@@ -1,5 +1,6 @@
 flow PRB2_MAIN {
 
+
     setup {
         suite mrd_ckbd calls ac_tml.AcTest.FunctionalTest {
             measurement.pattern = setupRef(OrigenTesters.patterns.mrd_ckbd);
@@ -18,7 +19,6 @@ flow PRB2_MAIN {
     }
 
     execute {
-
         pgm_ckbd.execute();
         mrd_ckbd.execute();
     }

--- a/approved/v93k_smt8/OrigenTesters/flows/prb2/PRB2_MAIN_1.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb2/PRB2_MAIN_1.flow
@@ -1,5 +1,6 @@
 flow PRB2_MAIN_1 {
 
+
     setup {
         suite mrd_ckbd calls ac_tml.AcTest.FunctionalTest {
             measurement.pattern = setupRef(OrigenTesters.patterns.mrd_ckbd);
@@ -18,7 +19,6 @@ flow PRB2_MAIN_1 {
     }
 
     execute {
-
         pgm_ckbd.execute();
         mrd_ckbd.execute();
     }

--- a/lib/origen_testers/atp/flow.rb
+++ b/lib/origen_testers/atp/flow.rb
@@ -337,8 +337,11 @@ module OrigenTesters::ATP
 
           name = (options[:name] || options[:tname] || options[:test_name])
           unless name
-            [:name, :tname, :test_name].each do |m|
-              name ||= instance.respond_to?(m) ? instance.send(m) : nil
+            # Starting in Ruby3 type Symbol responds to name
+            unless instance.is_a?(Symbol)
+              [:name, :tname, :test_name].each do |m|
+                name ||= instance.respond_to?(m) ? instance.send(m) : nil
+              end
             end
           end
           children << n1(:name, name) if name

--- a/lib/origen_testers/atp/parser.rb
+++ b/lib/origen_testers/atp/parser.rb
@@ -2,6 +2,7 @@ require 'sexpistol'
 module OrigenTesters::ATP
   class Parser < Sexpistol
     def initialize
+      # This accessor moves to Sexpistol::Parser in newer versions of the gem
       self.ruby_keyword_literals = true
     end
 

--- a/lib/origen_testers/decompiler/pattern.rb
+++ b/lib/origen_testers/decompiler/pattern.rb
@@ -51,7 +51,11 @@ module OrigenTesters
       include EnumerableExt
       include SpecHelpers
 
-      def initialize(source, direct_source: false, no_verify: false)
+      def initialize(source, options = {})
+        options = { direct_source: false, no_verify: false }.merge(options)
+        direct_source = options[:direct_source]
+        no_verify = options[:no_verify]
+
         if source.is_a?(File)
           source = source.path
         end

--- a/lib/origen_testers/decompiler/pattern/splitter.rb
+++ b/lib/origen_testers/decompiler/pattern/splitter.rb
@@ -52,7 +52,7 @@ module OrigenTesters
         end
 
         def split!
-          section_indices = split(splitter_config)
+          section_indices = split(**splitter_config)
 
           # Check that we found each section in the pattern.
           if section_indices[:pinlist_start].nil?

--- a/origen_testers.gemspec
+++ b/origen_testers.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rodf', '~>1'
   spec.add_runtime_dependency 'origen_stil', '>= 0.2.1'
   spec.add_runtime_dependency "ast", "~> 2"
-  spec.add_runtime_dependency "sexpistol", "~> 0.0"
+  spec.add_runtime_dependency "sexpistol", "= 0.0.7"
 end

--- a/spec/decompiler/platforms/j750.rb
+++ b/spec/decompiler/platforms/j750.rb
@@ -20,7 +20,7 @@ module OrigenTesters
           ext: '.atp',
         }
 
-        def self.handle_platform_specific_vector_body_element(context, vector_type, **test_setup)
+        def self.handle_platform_specific_vector_body_element(context, vector_type, test_setup = {})
           case vector_type
             when :start_label
               context.include_examples(:validate_start_label, test_setup)

--- a/spec/decompiler/platforms/v93k.rb
+++ b/spec/decompiler/platforms/v93k.rb
@@ -17,7 +17,7 @@ module OrigenTesters
           ext: '.avc',
         }
 
-        def self.handle_platform_specific_vector_body_element(context, vector_type, **test_setup)
+        def self.handle_platform_specific_vector_body_element(context, vector_type, test_setup = {})
           case vector_type
             when :sequencer_instruction
               context.include_examples(:sequencer_instruction, test_setup)


### PR DESCRIPTION
Passing with Ruby 3.0.4. Need the Ruby 3 compatible origen version released before adding Ruby 3 GA checks. Still needs:

- ~~Gemfile.lock updates pushed~~
- ~~Remove the temporary "rm Gemfile.lock" from GA~~

Note the changes to approved output. Blank lines got deleted/added to some smt8 output. Didn't feel it was worth chasing down. But, I also don't use that output.