### PR TITLE
more reliable pinlist start detection

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Update Env
       run: echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
     - name: Install Bundler
-      run: gem install bundler -v '> 2'
+      run: gem install bundler -v '2.1.4'
     - name: Install dependencies
       run: bundle install  
     - name: Gem Install Origen 

--- a/lib/origen_testers/igxl_based_tester/decompiler.rb
+++ b/lib/origen_testers/igxl_based_tester/decompiler.rb
@@ -19,7 +19,7 @@ module OrigenTesters
 
       @platform = 'j750'
       @splitter_config = {
-        pinlist_start:              /^vector/,
+        pinlist_start:              /\$tset/,
         vectors_start:              /^{/,
         vectors_end:                /^}/,
         vectors_include_start_line: false,

--- a/lib/origen_testers/igxl_based_tester/decompiler/atp.rb
+++ b/lib/origen_testers/igxl_based_tester/decompiler/atp.rb
@@ -33,6 +33,8 @@ module OrigenTesters
               imports[val.gsub(';', '')] = type
             elsif l.strip.empty?
               # Just whitespace. Ignore this, but don't throw an error
+            elsif !(l =~ Regexp.new(/vector/)).nil?
+              # line break between vector keyword and pinlist, ignore
             else
               Origen.app!.fail!("Unable to parse pattern frontmatter, at line: #{i}")
             end


### PR DESCRIPTION
This update is to handle the case where the pin list isn't on the same line as the vector key word (this is how Origen creates UltraFlex patterns).