### PR TITLE
Stil groups

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Update Env
       run: echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
     - name: Install Bundler
-      run: gem install bundler -v '> 2'
+      run: gem install bundler -v '2.1.4'
     - name: Install dependencies
       run: bundle install  
     - name: Gem Install Origen 

--- a/approved/stil/v93k_workout.stil
+++ b/approved/stil/v93k_workout.stil
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    09-Feb-2024 13:10PM
+//   Time:    13-Feb-2024 10:23AM
 //   By:      Paul DeRouen
 //   Mode:    debug
 //   Command: origen g v93k_workout -t legacy.rb -e stil.rb
@@ -9,7 +9,7 @@
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen_testers.git
 //     Version:   0.51.3
-//     Branch:    master(55e4e67f00d) (+local edits)
+//     Branch:    stil_groups(063718e8bff) (+local edits)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
 //     Version:   0.60.7
@@ -53,6 +53,8 @@ Signals {
 }
 
 SignalGroups {
+  "porta" = 'porta7+porta6+porta5+porta4+porta3+porta2+porta1+porta0';
+  "portb" = 'portb0+portb1+portb2+portb3+portb4+portb5+portb6+portb7';
   "ALL" = 'nvm_reset+nvm_clk+nvm_clk_mux+porta7+porta6+porta5+porta4+porta3+porta2+porta1+porta0+portb0+portb1+portb2+portb3+portb4+portb5+portb6+portb7+nvm_invoke+nvm_done+nvm_fail+nvm_alvtst+nvm_ahvtst+nvm_dtst+tclk+trst';
 }
 

--- a/approved/stil/v93k_workout.stil
+++ b/approved/stil/v93k_workout.stil
@@ -1,24 +1,24 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    07-May-2019 15:36PM
-//   By:      Stephen McGinty
+//   Time:    09-Feb-2024 13:10PM
+//   By:      Paul DeRouen
 //   Mode:    debug
 //   Command: origen g v93k_workout -t legacy.rb -e stil.rb
 // ***************************************************************************
 // ENVIRONMENT:
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen_testers.git
-//     Version:   0.20.0
-//     Branch:    smt8(a7ca95b19d0) (+local edits)
+//     Version:   0.51.3
+//     Branch:    master(55e4e67f00d) (+local edits)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
-//     Version:   0.43.0
+//     Version:   0.60.7
 //   Plugins
-//     atp:                      1.1.3
 //     origen_arm_debug:         0.4.3
-//     origen_doc_helpers:       0.8.0
-//     origen_jtag:              0.21.1
-//     origen_swd:               1.1.1
+//     origen_doc_helpers:       0.8.6
+//     origen_jtag:              0.22.2
+//     origen_stil:              0.3.0
+//     origen_swd:               1.1.2
 // ***************************************************************************
 STIL 1.0;
 
@@ -26,8 +26,22 @@ Signals {
   nvm_reset InOut;
   nvm_clk InOut;
   nvm_clk_mux InOut;
-  porta InOut;
-  portb InOut;
+  porta7 InOut;
+  porta6 InOut;
+  porta5 InOut;
+  porta4 InOut;
+  porta3 InOut;
+  porta2 InOut;
+  porta1 InOut;
+  porta0 InOut;
+  portb0 InOut;
+  portb1 InOut;
+  portb2 InOut;
+  portb3 InOut;
+  portb4 InOut;
+  portb5 InOut;
+  portb6 InOut;
+  portb7 InOut;
   nvm_invoke InOut;
   nvm_done InOut;
   nvm_fail InOut;
@@ -39,7 +53,7 @@ Signals {
 }
 
 SignalGroups {
-  "ALL" = 'nvm_reset+nvm_clk+nvm_clk_mux+porta+portb+nvm_invoke+nvm_done+nvm_fail+nvm_alvtst+nvm_ahvtst+nvm_dtst+tclk+trst';
+  "ALL" = 'nvm_reset+nvm_clk+nvm_clk_mux+porta7+porta6+porta5+porta4+porta3+porta2+porta1+porta0+portb0+portb1+portb2+portb3+portb4+portb5+portb6+portb7+nvm_invoke+nvm_done+nvm_fail+nvm_alvtst+nvm_ahvtst+nvm_dtst+tclk+trst';
 }
 
 Timing t_v93k_workout {
@@ -52,10 +66,38 @@ Timing t_v93k_workout {
       nvm_clk { LHX { }}
       nvm_clk_mux { 01 { }}
       nvm_clk_mux { LHX { }}
-      porta { 01 { }}
-      porta { LHX { }}
-      portb { 01 { }}
-      portb { LHX { }}
+      porta7 { 01 { }}
+      porta7 { LHX { }}
+      porta6 { 01 { }}
+      porta6 { LHX { }}
+      porta5 { 01 { }}
+      porta5 { LHX { }}
+      porta4 { 01 { }}
+      porta4 { LHX { }}
+      porta3 { 01 { }}
+      porta3 { LHX { }}
+      porta2 { 01 { }}
+      porta2 { LHX { }}
+      porta1 { 01 { }}
+      porta1 { LHX { }}
+      porta0 { 01 { }}
+      porta0 { LHX { }}
+      portb0 { 01 { }}
+      portb0 { LHX { }}
+      portb1 { 01 { }}
+      portb1 { LHX { }}
+      portb2 { 01 { }}
+      portb2 { LHX { }}
+      portb3 { 01 { }}
+      portb3 { LHX { }}
+      portb4 { 01 { }}
+      portb4 { LHX { }}
+      portb5 { 01 { }}
+      portb5 { LHX { }}
+      portb6 { 01 { }}
+      portb6 { LHX { }}
+      portb7 { 01 { }}
+      portb7 { LHX { }}
       nvm_invoke { 01 { }}
       nvm_invoke { LHX { }}
       nvm_done { 01 { }}

--- a/lib/origen_testers/stil_based_tester/base.rb
+++ b/lib/origen_testers/stil_based_tester/base.rb
@@ -45,6 +45,17 @@ module OrigenTesters
         @flattened_ordered_pins
       end
 
+      def output_group_definition(grp, grp_name)
+        line = "\"#{grp_name}\" = '"
+        grp.each_with_index do |pin, i|
+          unless i == 0
+            line << '+'
+          end
+          line << pin.name.to_s
+        end
+        microcode "  #{line}';"
+      end
+
       # An internal method called by Origen to create the pattern header
       def pattern_header(options = {})
         options = {
@@ -73,14 +84,13 @@ module OrigenTesters
 
           microcode ''
           microcode 'SignalGroups {'
-          line = "\"#{ordered_pins_name || 'ALL'}\" = '"
-          flattened_ordered_pins.each_with_index do |pin, i|
-            unless i == 0
-              line << '+'
-            end
-            line << pin.name.to_s
+          # output pin group definitions used in this pattern
+          ordered_pins.each do |p|
+            output_group_definition(p, p.name.to_s) if p.is_a?(Origen::Pins::PinCollection)
           end
-          microcode "  #{line}';"
+
+          # output the all pin group
+          output_group_definition(flattened_ordered_pins, "#{ordered_pins_name || 'ALL'}")
           microcode '}'
 
           microcode ''

--- a/lib/origen_testers/stil_based_tester/base.rb
+++ b/lib/origen_testers/stil_based_tester/base.rb
@@ -30,6 +30,21 @@ module OrigenTesters
         true
       end
 
+      # returns the orderd pins with groups decomposed into individual pins
+      def flattened_ordered_pins
+        if @flattened_ordered_pins.nil?
+          @flattened_ordered_pins = []
+          ordered_pins.each do |p|
+            if p.is_a?(Origen::Pins::PinCollection)
+              p.each { |ip| @flattened_ordered_pins << ip }
+            else
+              @flattened_ordered_pins << p
+            end
+          end
+        end
+        @flattened_ordered_pins
+      end
+
       # An internal method called by Origen to create the pattern header
       def pattern_header(options = {})
         options = {
@@ -42,7 +57,7 @@ module OrigenTesters
 
           microcode ''
           microcode 'Signals {'
-          ordered_pins.each do |pin|
+          flattened_ordered_pins.each do |pin|
             line = ''
             line << "#{pin.name} "
             if pin.direction == :input
@@ -59,7 +74,7 @@ module OrigenTesters
           microcode ''
           microcode 'SignalGroups {'
           line = "\"#{ordered_pins_name || 'ALL'}\" = '"
-          ordered_pins.each_with_index do |pin, i|
+          flattened_ordered_pins.each_with_index do |pin, i|
             unless i == 0
               line << '+'
             end
@@ -120,7 +135,7 @@ module OrigenTesters
           end
           unless wave_number
             lines = []
-            ordered_pins.each do |pin|
+            flattened_ordered_pins.each do |pin|
               if pin.direction == :input || pin.direction == :io
                 line = "#{pin.name} { 01 { "
                 wave = pin.drive_wave if tester.timeset.dut_timeset
@@ -128,7 +143,7 @@ module OrigenTesters
                   line << "'#{t}ns' "
                   if v == 0
                     line << 'D'
-                  elsif v == 0
+                  elsif v == 1
                     line << 'U'
                   else
                     line << 'D/U'


### PR DESCRIPTION
Previously if a pin group was listed in the pin_pattern_order statement it was treated as though it was a single pin in the signal definition and timing definition sections of the output STIL. This PR is to include all of the pins from the group (see the 1 approved output change for an example).