### PR TITLE
remove extra spaces before converting to symbol

### DIFF
--- a/lib/origen_testers/decompiler/nodes.rb
+++ b/lib/origen_testers/decompiler/nodes.rb
@@ -103,7 +103,7 @@ module OrigenTesters
         alias_method :pinlist, :pins
 
         def initialize(pins:, context:)
-          @pins = pins.map(&:to_sym)
+          @pins = pins.map(&:strip).map(&:to_sym)
           super(context: context, type: :pinlist)
         end
       end


### PR DESCRIPTION
The reverse compiler (from a binary pattern file back to an ASCII pattern file) adds extra spaces to the pin list. The origen decompiler was turning that into a list of pins with a lot of spaces in their names (which don't exist in the app).