### PR TITLE
SMT8 does not require an initialization of the loop variable, it erro…

### DIFF
--- a/approved/v93k_flowgrouping/OrigenTesters/flows/FLOW_CONTROL.flow
+++ b/approved/v93k_flowgrouping/OrigenTesters/flows/FLOW_CONTROL.flow
@@ -9,10 +9,6 @@ flow FLOW_CONTROL {
     in EXTRAS = -1;
     in FLAG1 = -1;
     in JOB = "";
-    in LOOP_VARIABLE = -1;
-    in LOOP_VARIABLE1 = -1;
-    in LOOP_VARIABLE2 = -1;
-    in LOOP_VARIABLE3 = -1;
     in LT_VARIABLE = -1;
     in MCEn_extras = -1;
     in MCEn_test = -1;
@@ -1620,31 +1616,25 @@ flow FLOW_CONTROL {
         } else {
         }
         println("Tests of flow loop");
-        LOOP_VARIABLE = 0;
         for (LOOP_VARIABLE : 0..5)
         {
             test_myloop.execute();
         }
         println("Tests of flow loop, no step");
-        LOOP_VARIABLE = 0;
         for (LOOP_VARIABLE : 0..5)
         {
             test_myloop2.execute();
         }
         println("Tests of decrementing loop");
-        LOOP_VARIABLE = 0;
         for (LOOP_VARIABLE : 5..2)
         {
             test_myloop4.execute();
         }
         println("Tests of nested flow loop, depth 3");
-        LOOP_VARIABLE1 = 0;
         for (LOOP_VARIABLE1 : 0..9)
         {
-            LOOP_VARIABLE2 = 0;
             for (LOOP_VARIABLE2 : 1..10)
             {
-                LOOP_VARIABLE3 = 0;
                 for (LOOP_VARIABLE3 : 1..5)
                 {
                     test_myloop5.execute();
@@ -1652,7 +1642,6 @@ flow FLOW_CONTROL {
             }
         }
         println("Tests of variable loop");
-        LOOP_VARIABLE = 0;
         for (LOOP_VARIABLE : TEST_VAR..1)
         {
             test_myloop6.execute();

--- a/approved/v93k_smt8/OrigenTesters/flows/FLOW_CONTROL.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/FLOW_CONTROL.flow
@@ -9,10 +9,6 @@ flow FLOW_CONTROL {
     in EXTRAS = -1;
     in FLAG1 = -1;
     in JOB = "";
-    in LOOP_VARIABLE = -1;
-    in LOOP_VARIABLE1 = -1;
-    in LOOP_VARIABLE2 = -1;
-    in LOOP_VARIABLE3 = -1;
     in LT_VARIABLE = -1;
     in MCEn_extras = -1;
     in MCEn_test = -1;
@@ -1620,31 +1616,25 @@ flow FLOW_CONTROL {
         } else {
         }
         println("Tests of flow loop");
-        LOOP_VARIABLE = 0;
         for (LOOP_VARIABLE : 0..5)
         {
             test_myloop.execute();
         }
         println("Tests of flow loop, no step");
-        LOOP_VARIABLE = 0;
         for (LOOP_VARIABLE : 0..5)
         {
             test_myloop2.execute();
         }
         println("Tests of decrementing loop");
-        LOOP_VARIABLE = 0;
         for (LOOP_VARIABLE : 5..2)
         {
             test_myloop4.execute();
         }
         println("Tests of nested flow loop, depth 3");
-        LOOP_VARIABLE1 = 0;
         for (LOOP_VARIABLE1 : 0..9)
         {
-            LOOP_VARIABLE2 = 0;
             for (LOOP_VARIABLE2 : 1..10)
             {
-                LOOP_VARIABLE3 = 0;
                 for (LOOP_VARIABLE3 : 1..5)
                 {
                     test_myloop5.execute();
@@ -1652,7 +1642,6 @@ flow FLOW_CONTROL {
             }
         }
         println("Tests of variable loop");
-        LOOP_VARIABLE = 0;
         for (LOOP_VARIABLE : TEST_VAR..1)
         {
             test_myloop6.execute();

--- a/lib/origen_testers/atp/flow.rb
+++ b/lib/origen_testers/atp/flow.rb
@@ -639,7 +639,9 @@ module OrigenTesters::ATP
       end
       # Add node for set of flag to be used for loop
       unless args[0][:var].nil?
-        set(args[0][:var], 0)
+        unless tester.smt8?
+          set(args[0][:var], 0)
+        end
       end
       extract_meta!(options) do
         apply_conditions(options) do


### PR DESCRIPTION
SMT8 errors if the loop variable is initialized like other flow variables. The variable population had to be removed for it to run properly on the tester.