### PR TITLE
Allow Ruby loop keyword within flow

### DIFF
--- a/lib/origen_testers/atp/flow.rb
+++ b/lib/origen_testers/atp/flow.rb
@@ -626,33 +626,37 @@ module OrigenTesters::ATP
     end
 
     def loop(*args, &block)
-      unless args[0].keys.include?(:from) && args[0].keys.include?(:to)
-        fail 'Loop must specify :from, :to'
-      end
-      # assume 1 if :step not provided
-      unless args[0].keys.include?(:step)
-        args[0][:step] = 1
-      end
-      # assume 1 if :test_num_inc not provided
-      unless args[0].keys.include?(:test_num_inc)
-        args[0][:test_num_inc] = 1
-      end
-      # Add node for set of flag to be used for loop
-      unless args[0][:var].nil?
-        unless tester.smt8?
-          set(args[0][:var], 0)
+      if !args[0].except(:source_file, :source_line_number).empty?
+        unless args[0].keys.include?(:from) && args[0].keys.include?(:to)
+          fail 'Loop must specify :from, :to'
         end
-      end
-      extract_meta!(options) do
-        apply_conditions(options) do
-          # always pass 5-element array to loop node to simplify downstream parser
-          #   element, 'var', will be nil if not specified by loop call
-          params = [args[0][:from], args[0][:to], args[0][:step], args[0][:var], args[0][:test_num_inc]]
+        # assume 1 if :step not provided
+        unless args[0].keys.include?(:step)
+          args[0][:step] = 1
+        end
+        # assume 1 if :test_num_inc not provided
+        unless args[0].keys.include?(:test_num_inc)
+          args[0][:test_num_inc] = 1
+        end
+        # Add node for set of flag to be used for loop
+        unless args[0][:var].nil?
+          unless tester.smt8?
+            set(args[0][:var], 0)
+          end
+        end
+        extract_meta!(options) do
+          apply_conditions(options) do
+            # always pass 5-element array to loop node to simplify downstream parser
+            #   element, 'var', will be nil if not specified by loop call
+            params = [args[0][:from], args[0][:to], args[0][:step], args[0][:var], args[0][:test_num_inc]]
 
-          node = n(:loop, params)
-          node = append_to(node) { block.call }
-          node
+            node = n(:loop, params)
+            node = append_to(node) { block.call }
+            node
+          end
         end
+      else
+        super(&block)
       end
     end
 

--- a/lib/origen_testers/atp/flow.rb
+++ b/lib/origen_testers/atp/flow.rb
@@ -626,7 +626,10 @@ module OrigenTesters::ATP
     end
 
     def loop(*args, &block)
-      if !args[0].except(:source_file, :source_line_number).empty?
+      if args[0].except(:source_file, :source_line_number).empty?
+        # not a flow api call, just a loop block
+        super(&block)
+      else
         unless args[0].keys.include?(:from) && args[0].keys.include?(:to)
           fail 'Loop must specify :from, :to'
         end
@@ -655,8 +658,6 @@ module OrigenTesters::ATP
             node
           end
         end
-      else
-        super(&block)
       end
     end
 

--- a/origen_testers.gemspec
+++ b/origen_testers.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'origen_stil', '>= 0.2.1'
   spec.add_runtime_dependency "ast", "~> 2"
   spec.add_runtime_dependency "sexpistol", "= 0.0.7"
+  spec.add_runtime_dependency "parallel", ">= 1.24"
 end

--- a/spec/atp/loop_spec.rb
+++ b/spec/atp/loop_spec.rb
@@ -57,12 +57,12 @@ describe 'Loop Support' do
       s(:name, "sort1"),
       s(:test,
         s(:object, "test_pre_loop")),
-          s(:test,
-            s(:object, "test_loop1")),
-          s(:test,
-            s(:object, "test_loop2")),
-          s(:test,
-            s(:object, "test_loop3")))
+      s(:test,
+        s(:object, "test_loop1")),
+      s(:test,
+        s(:object, "test_loop2")),
+      s(:test,
+        s(:object, "test_loop3")))
   end
 end
 

--- a/spec/atp/loop_spec.rb
+++ b/spec/atp/loop_spec.rb
@@ -43,6 +43,27 @@ describe 'Loop Support' do
         s(:test,
           s(:object, "test_post_loop")))
   end
+
+  it "can cede to ruby loop keyword" do
+    test :test_pre_loop
+    id = 1
+    loop do
+      test "test_loop#{id}".to_sym
+      id += 1
+      break if id > 3
+    end
+    atp.raw.should ==
+    s(:flow,
+      s(:name, "sort1"),
+      s(:test,
+        s(:object, "test_pre_loop")),
+          s(:test,
+            s(:object, "test_loop1")),
+          s(:test,
+            s(:object, "test_loop2")),
+          s(:test,
+            s(:object, "test_loop3")))
+  end
 end
 
 


### PR DESCRIPTION
Revert to Ruby loop keyword functionality if only block is given with no args, otherwise treat as testflow loop api.