### PR TITLE
add option to add insertion in the flow path

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base.rb
+++ b/lib/origen_testers/smartest_based_tester/base.rb
@@ -83,6 +83,10 @@ module OrigenTesters
       # (SMT8 only)
       attr_accessor :print_all_params
 
+      # When set to true, the flow path will have insertion in the subdirectories
+      # (SMT8 only)
+      attr_reader :insertion_in_the_flow_path
+
       def initialize(options = {})
         options = {
           # whether to use multiport bursts or not, if so this indicates the name of the port to use
@@ -132,6 +136,7 @@ module OrigenTesters
         @capture_style = :hram			# default to use hram for capture
         @overlay_subr = nil
         @overlay_history = {} # used to track labels, subroutines, digsrc pins used etc
+        @insertion_in_the_flow_path = options[:insertion_in_the_flow_path] # add insertion for path to the flows
 
         if options[:add_flow_enable]
           self.add_flow_enable = options[:add_flow_enable]

--- a/lib/origen_testers/smartest_based_tester/base/flow.rb
+++ b/lib/origen_testers/smartest_based_tester/base/flow.rb
@@ -50,8 +50,7 @@ module OrigenTesters
                 parents.unshift(File.basename(f.filename, '.*').to_s.downcase)
                 f = f.parent
               end
-              # need to variablize this for internal usage!!
-              if Origen.interface.respond_to?(:insertion)
+              if Origen.interface.respond_to?(:insertion) && tester.insertion_in_the_flow_path
                 File.join tester.package_namespace, Origen.interface.insertion.to_s, 'flows', *parents
               else
                 File.join tester.package_namespace, 'flows', *parents


### PR DESCRIPTION
This is an update to the commit on 10/6/2023.  We need to keep the existing behavior that is no insertion in the flow path.

Add in an option to add the insertion.  In the environment/v93k_smt8.rb

add insertion_in_the_flow_path: true