### PR TITLE
Force integer and double to their respective types

### DIFF
--- a/approved/v93k/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k/testflow/mfh.testflow.group/prb1.tf
@@ -13,21 +13,8 @@ tm_100:
   "output" = "None";
   "testName" = "Functional";
 tm_101:
-  "forceMode" = "VOLT";
-  "forceValue" = "3.8[V]";
-  "measureMode" = "PPMUpar";
-  "output" = "None";
-  "pinlist" = "@";
-  "ppmuClampHigh" = "0[V]";
-  "ppmuClampLow" = "0[V]";
-  "precharge" = "OFF";
-  "prechargeVoltage" = "0[V]";
-  "relaySwitchMode" = "DEFAULT(BBM)";
-  "settlingTime" = "0[s]";
-  "spmuClamp" = "0[A]";
-  "termination" = "OFF";
-  "testName" = "passLimit_uA_mV";
-  "testerState" = "CONNECTED";
+  "double" = "1.0";
+  "int" = "1";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";
@@ -176,8 +163,21 @@ tm_110:
   "testName" = "passLimit_uA_mV";
   "testerState" = "CONNECTED";
 tm_111:
+  "forceMode" = "VOLT";
+  "forceValue" = "3.8[V]";
+  "measureMode" = "PPMUpar";
   "output" = "None";
-  "testName" = "Functional";
+  "pinlist" = "@";
+  "ppmuClampHigh" = "0[V]";
+  "ppmuClampLow" = "0[V]";
+  "precharge" = "OFF";
+  "prechargeVoltage" = "0[V]";
+  "relaySwitchMode" = "DEFAULT(BBM)";
+  "settlingTime" = "0[s]";
+  "spmuClamp" = "0[A]";
+  "termination" = "OFF";
+  "testName" = "passLimit_uA_mV";
+  "testerState" = "CONNECTED";
 tm_112:
   "output" = "None";
   "testName" = "Functional";
@@ -203,6 +203,9 @@ tm_119:
   "output" = "None";
   "testName" = "Functional";
 tm_12:
+  "output" = "None";
+  "testName" = "Functional";
+tm_120:
   "output" = "None";
   "testName" = "Functional";
 tm_13:
@@ -502,29 +505,29 @@ tm_10:
 tm_100:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_101:
-  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
+  "Functional" = "":"NA":"":"NA":"":"":"";
 tm_102:
-  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
 tm_103:
-  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
 tm_104:
   "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_105:
-  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_106:
   "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_107:
-  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_108:
-  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
 tm_109:
-  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
 tm_11:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_110:
-  "passLimit_uA_mV" = "[1.0e-06, 2.0e-06, 3.0e-06]":"GE":"[4.0e-06, 5.0e-06]":"LE":"":"":"0";
+  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
 tm_111:
-  "Functional" = "":"NA":"":"NA":"":"":"";
+  "passLimit_uA_mV" = "[1.0e-06, 2.0e-06, 3.0e-06]":"GE":"[4.0e-06, 5.0e-06]":"LE":"":"":"0";
 tm_112:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_113:
@@ -542,6 +545,8 @@ tm_118:
 tm_119:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_12:
+  "Functional" = "":"NA":"":"NA":"":"":"";
+tm_120:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_13:
   "Functional" = "":"NA":"":"NA":"":"":"";
@@ -745,7 +750,7 @@ tm_10:
 tm_100:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_101:
-  testmethod_class = "dc_tml.DcTest.GeneralPMU";
+  testmethod_class = "MyTypeCheck.MyHashExampleClass";
 tm_102:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_103:
@@ -767,7 +772,7 @@ tm_11:
 tm_110:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_111:
-  testmethod_class = "ac_tml.AcTest.FunctionalTest";
+  testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_112:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_113:
@@ -785,6 +790,8 @@ tm_118:
 tm_119:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_12:
+  testmethod_class = "ac_tml.AcTest.FunctionalTest";
+tm_120:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_13:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
@@ -992,28 +999,28 @@ bitcell_iv_0_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "bitcell_iv_0";
-  override_testf = tm_113;
+  override_testf = tm_114;
   site_control = "parallel:";
   site_match = 2;
 bitcell_iv_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "bitcell_iv_1";
-  override_testf = tm_114;
+  override_testf = tm_115;
   site_control = "parallel:";
   site_match = 2;
 bitcell_iv_2_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "bitcell_iv_2";
-  override_testf = tm_115;
+  override_testf = tm_116;
   site_control = "parallel:";
   site_match = 2;
 bitmap_all0_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "bitmap_all0";
-  override_testf = tm_112;
+  override_testf = tm_113;
   site_control = "parallel:";
   site_match = 2;
 cc_test_0_864CE8F:
@@ -1279,7 +1286,7 @@ erase_all_41_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "erase_all";
-  override_testf = tm_119;
+  override_testf = tm_120;
   site_control = "parallel:";
   site_match = 2;
 erase_all_4_864CE8F:
@@ -1349,7 +1356,7 @@ margin_read0_ckbd_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "margin_read0_ckbd";
-  override_testf = tm_118;
+  override_testf = tm_119;
   site_control = "parallel:";
   site_match = 2;
 margin_read0_ckbd_864CE8F:
@@ -1511,7 +1518,7 @@ margin_read1_ckbd_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "margin_read1_ckbd";
-  override_testf = tm_116;
+  override_testf = tm_117;
   site_control = "parallel:";
   site_match = 2;
 margin_read1_ckbd_864CE8F:
@@ -1525,70 +1532,70 @@ meas_read_pump_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_102;
+  override_testf = tm_103;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_2_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_103;
+  override_testf = tm_104;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_3_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_104;
+  override_testf = tm_105;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_4_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_105;
+  override_testf = tm_106;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_5_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_106;
+  override_testf = tm_107;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_6_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_107;
+  override_testf = tm_108;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_7_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_108;
+  override_testf = tm_109;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_101;
+  override_testf = tm_102;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_8_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_109;
+  override_testf = tm_110;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_9_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_110;
+  override_testf = tm_111;
   site_control = "parallel:";
   site_match = 2;
 mixed_flag_check_864CE8F:
@@ -1602,7 +1609,7 @@ normal_read_ckbd_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "normal_read_ckbd";
-  override_testf = tm_117;
+  override_testf = tm_118;
   site_control = "parallel:";
   site_match = 2;
 not_p1_or_p2_test_864CE8F:
@@ -1693,7 +1700,7 @@ program_ckbd_17_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "program_ckbd";
-  override_testf = tm_111;
+  override_testf = tm_112;
   site_control = "parallel:";
   site_match = 2;
 program_ckbd_1_864CE8F:
@@ -1786,6 +1793,12 @@ test_with_no_flags_864CE8F:
   override_testf = tm_97;
   site_control = "parallel:";
   site_match = 2;
+type_check_864CE8F:
+  local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
+  override = 1;
+  override_testf = tm_101;
+  site_control = "parallel:";
+  site_match = 2;
 xcvr_fs_vilvih_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
@@ -1838,6 +1851,7 @@ test_flow
        @G100_864CE8F_RAN = -1;
        @DEEP_TEST_864CE8F_FAILED = -1;
     }, open,"Init Flow Control Vars", ""
+    print_dl("PRB1 Test Flow Version 00001 - do not copy me to approved!");
     {
        run_and_branch(program_ckbd_864CE8F)
        then
@@ -2344,6 +2358,7 @@ test_flow
        print_dl("force_serial test method parameter can be programmed");
        run(force_serial_true_test_864CE8F);
        run(force_serial_false_test_864CE8F);
+       run(type_check_864CE8F);
     }, open,"prb1_main", ""
     {
        run_and_branch(meas_read_pump_864CE8F)

--- a/approved/v93k_disable_flow/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_disable_flow/testflow/mfh.testflow.group/prb1.tf
@@ -13,21 +13,8 @@ tm_100:
   "output" = "None";
   "testName" = "Functional";
 tm_101:
-  "forceMode" = "VOLT";
-  "forceValue" = "3.8[V]";
-  "measureMode" = "PPMUpar";
-  "output" = "None";
-  "pinlist" = "@";
-  "ppmuClampHigh" = "0[V]";
-  "ppmuClampLow" = "0[V]";
-  "precharge" = "OFF";
-  "prechargeVoltage" = "0[V]";
-  "relaySwitchMode" = "DEFAULT(BBM)";
-  "settlingTime" = "0[s]";
-  "spmuClamp" = "0[A]";
-  "termination" = "OFF";
-  "testName" = "passLimit_uA_mV";
-  "testerState" = "CONNECTED";
+  "double" = "1.0";
+  "int" = "1";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";
@@ -160,6 +147,22 @@ tm_11:
   "output" = "None";
   "testName" = "Functional";
 tm_110:
+  "forceMode" = "VOLT";
+  "forceValue" = "3.8[V]";
+  "measureMode" = "PPMUpar";
+  "output" = "None";
+  "pinlist" = "@";
+  "ppmuClampHigh" = "0[V]";
+  "ppmuClampLow" = "0[V]";
+  "precharge" = "OFF";
+  "prechargeVoltage" = "0[V]";
+  "relaySwitchMode" = "DEFAULT(BBM)";
+  "settlingTime" = "0[s]";
+  "spmuClamp" = "0[A]";
+  "termination" = "OFF";
+  "testName" = "passLimit_uA_mV";
+  "testerState" = "CONNECTED";
+tm_111:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";
   "measureMode" = "PPMUpar";
@@ -475,26 +478,28 @@ tm_10:
 tm_100:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_101:
-  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
+  "Functional" = "":"NA":"":"NA":"":"":"";
 tm_102:
-  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
 tm_103:
-  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
 tm_104:
   "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_105:
-  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_106:
   "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_107:
-  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_108:
-  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
 tm_109:
-  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
 tm_11:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_110:
+  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
+tm_111:
   "passLimit_uA_mV" = "[1.0e-06, 2.0e-06, 3.0e-06]":"GE":"[4.0e-06, 5.0e-06]":"LE":"":"":"0";
 tm_12:
   "Functional" = "":"NA":"":"NA":"":"":"";
@@ -700,7 +705,7 @@ tm_10:
 tm_100:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_101:
-  testmethod_class = "dc_tml.DcTest.GeneralPMU";
+  testmethod_class = "MyTypeCheck.MyHashExampleClass";
 tm_102:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_103:
@@ -720,6 +725,8 @@ tm_109:
 tm_11:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_110:
+  testmethod_class = "dc_tml.DcTest.GeneralPMU";
+tm_111:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_12:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
@@ -1413,70 +1420,70 @@ meas_read_pump_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_102;
+  override_testf = tm_103;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_2_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_103;
+  override_testf = tm_104;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_3_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_104;
+  override_testf = tm_105;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_4_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_105;
+  override_testf = tm_106;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_5_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_106;
+  override_testf = tm_107;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_6_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_107;
+  override_testf = tm_108;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_7_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_108;
+  override_testf = tm_109;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_101;
+  override_testf = tm_102;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_8_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_109;
+  override_testf = tm_110;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_9_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_110;
+  override_testf = tm_111;
   site_control = "parallel:";
   site_match = 2;
 mixed_flag_check_864CE8F:
@@ -1660,6 +1667,12 @@ test_with_no_flags_864CE8F:
   override_testf = tm_97;
   site_control = "parallel:";
   site_match = 2;
+type_check_864CE8F:
+  local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
+  override = 1;
+  override_testf = tm_101;
+  site_control = "parallel:";
+  site_match = 2;
 xcvr_fs_vilvih_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
@@ -1714,6 +1727,7 @@ test_flow
           @G100_864CE8F_RAN = -1;
           @DEEP_TEST_864CE8F_FAILED = -1;
        }, open,"Init Flow Control Vars", ""
+       print_dl("PRB1 Test Flow Version 00001 - do not copy me to approved!");
        {
           run_and_branch(program_ckbd_864CE8F)
           then
@@ -2220,6 +2234,7 @@ test_flow
           print_dl("force_serial test method parameter can be programmed");
           run(force_serial_true_test_864CE8F);
           run(force_serial_false_test_864CE8F);
+          run(type_check_864CE8F);
        }, open,"prb1_main", ""
        {
           run_and_branch(meas_read_pump_864CE8F)

--- a/approved/v93k_enable_flow/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_enable_flow/testflow/mfh.testflow.group/prb1.tf
@@ -13,21 +13,8 @@ tm_100:
   "output" = "None";
   "testName" = "Functional";
 tm_101:
-  "forceMode" = "VOLT";
-  "forceValue" = "3.8[V]";
-  "measureMode" = "PPMUpar";
-  "output" = "None";
-  "pinlist" = "@";
-  "ppmuClampHigh" = "0[V]";
-  "ppmuClampLow" = "0[V]";
-  "precharge" = "OFF";
-  "prechargeVoltage" = "0[V]";
-  "relaySwitchMode" = "DEFAULT(BBM)";
-  "settlingTime" = "0[s]";
-  "spmuClamp" = "0[A]";
-  "termination" = "OFF";
-  "testName" = "passLimit_uA_mV";
-  "testerState" = "CONNECTED";
+  "double" = "1.0";
+  "int" = "1";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";
@@ -160,6 +147,22 @@ tm_11:
   "output" = "None";
   "testName" = "Functional";
 tm_110:
+  "forceMode" = "VOLT";
+  "forceValue" = "3.8[V]";
+  "measureMode" = "PPMUpar";
+  "output" = "None";
+  "pinlist" = "@";
+  "ppmuClampHigh" = "0[V]";
+  "ppmuClampLow" = "0[V]";
+  "precharge" = "OFF";
+  "prechargeVoltage" = "0[V]";
+  "relaySwitchMode" = "DEFAULT(BBM)";
+  "settlingTime" = "0[s]";
+  "spmuClamp" = "0[A]";
+  "termination" = "OFF";
+  "testName" = "passLimit_uA_mV";
+  "testerState" = "CONNECTED";
+tm_111:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";
   "measureMode" = "PPMUpar";
@@ -475,26 +478,28 @@ tm_10:
 tm_100:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_101:
-  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
+  "Functional" = "":"NA":"":"NA":"":"":"";
 tm_102:
-  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
 tm_103:
-  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
 tm_104:
   "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_105:
-  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_106:
   "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_107:
-  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_108:
-  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
 tm_109:
-  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
 tm_11:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_110:
+  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
+tm_111:
   "passLimit_uA_mV" = "[1.0e-06, 2.0e-06, 3.0e-06]":"GE":"[4.0e-06, 5.0e-06]":"LE":"":"":"0";
 tm_12:
   "Functional" = "":"NA":"":"NA":"":"":"";
@@ -700,7 +705,7 @@ tm_10:
 tm_100:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_101:
-  testmethod_class = "dc_tml.DcTest.GeneralPMU";
+  testmethod_class = "MyTypeCheck.MyHashExampleClass";
 tm_102:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_103:
@@ -720,6 +725,8 @@ tm_109:
 tm_11:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_110:
+  testmethod_class = "dc_tml.DcTest.GeneralPMU";
+tm_111:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_12:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
@@ -1413,70 +1420,70 @@ meas_read_pump_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_102;
+  override_testf = tm_103;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_2_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_103;
+  override_testf = tm_104;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_3_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_104;
+  override_testf = tm_105;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_4_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_105;
+  override_testf = tm_106;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_5_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_106;
+  override_testf = tm_107;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_6_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_107;
+  override_testf = tm_108;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_7_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_108;
+  override_testf = tm_109;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_101;
+  override_testf = tm_102;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_8_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_109;
+  override_testf = tm_110;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_9_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_110;
+  override_testf = tm_111;
   site_control = "parallel:";
   site_match = 2;
 mixed_flag_check_864CE8F:
@@ -1660,6 +1667,12 @@ test_with_no_flags_864CE8F:
   override_testf = tm_97;
   site_control = "parallel:";
   site_match = 2;
+type_check_864CE8F:
+  local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
+  override = 1;
+  override_testf = tm_101;
+  site_control = "parallel:";
+  site_match = 2;
 xcvr_fs_vilvih_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
@@ -1714,6 +1727,7 @@ test_flow
           @G100_864CE8F_RAN = -1;
           @DEEP_TEST_864CE8F_FAILED = -1;
        }, open,"Init Flow Control Vars", ""
+       print_dl("PRB1 Test Flow Version 00001 - do not copy me to approved!");
        {
           run_and_branch(program_ckbd_864CE8F)
           then
@@ -2220,6 +2234,7 @@ test_flow
           print_dl("force_serial test method parameter can be programmed");
           run(force_serial_true_test_864CE8F);
           run(force_serial_false_test_864CE8F);
+          run(type_check_864CE8F);
        }, open,"prb1_main", ""
        {
           run_and_branch(meas_read_pump_864CE8F)

--- a/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -271,17 +271,20 @@ flow PRB1_MAIN {
                 param_list_strings = #["E1", "E2"];
                 param_list_classes = #[E1, E2];
                 param_name1[my_param_name1] = {
-                    param_name0 = 1;
+                    param_name_int = 1;
+                    param_name_double = 1.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
                 };
                 param_name1[my_param_name2] = {
-                    param_name0 = 2;
+                    param_name_int = 2;
+                    param_name_double = 2.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
                 };
                 param_name1[my_param_name3] = {
-                    param_name0 = 3;
+                    param_name_int = 3;
+                    param_name_double = 0.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
                 };
@@ -289,18 +292,18 @@ flow PRB1_MAIN {
             nestedHashParameter2[my_param_name4] = {
                 param_name0 = "goodbye";
                 param_name1[param0] = {
-                    param_name0 = 0;
+                    param_name_int = 0;
                 };
             };
             nestedHashParameter2[my_param_name5] = {
                 param_name0 = "goodbye forever";
                 param_name1[param0] = {
-                    param_name0 = 0;
+                    param_name_int = 0;
                 };
             };
             pinList = "";
             prechargeVoltage = "0[V]";
-            samples = 1;
+            samples = 2;
             settlingTime = "0[s]";
             testName = "HashExample";
             testerState = "CONNECTED";
@@ -551,6 +554,11 @@ flow PRB1_MAIN {
             measurement.specification = setupRef(OrigenTesters.specs.specs.Nominal);
             output = "None";
             testName = "Functional";
+        }
+
+        suite type_check calls myTypeCheck.MyHashExampleClass {
+            double = 1.0;
+            int = 1;
         }
 
         suite xcvr_fs_vilvih calls ac_tml.AcTest.FunctionalTest {
@@ -860,5 +868,6 @@ flow PRB1_MAIN {
         }
         test_with_no_flags.execute();
         test_with_flags.execute();
+        type_check.execute();
     }
 }

--- a/approved/v93k_flowgrouping/OrigenTesters/limits/Main.PRB1_Tests.csv
+++ b/approved/v93k_flowgrouping/OrigenTesters/limits/Main.PRB1_Tests.csv
@@ -106,6 +106,7 @@ PRB1_MAIN.cc_test_2,cc_test_2,7002,cc_test_2,0,0,,
 PRB1_MAIN.DEEP_NESTED.deep_test,deep_test,,deep_test,0,0,,
 PRB1_MAIN.test_with_no_flags,test_with_no_flags,6020,test_with_no_flags,0,0,,
 PRB1_MAIN.test_with_flags,test_with_flags,6030,test_with_flags,0,0,,
+PRB1_MAIN.type_check,type_check,6035,type_check,0,0,,
 TEST.program_ckbd,program_ckbd,40000,program_ckbd,0,0,,1100
 TEST.meas_read_pump,meas_read_pump,40005,meas_read_pump,,35,,2
 TEST.meas_read_pump_1,meas_read_pump_1,40010,meas_read_pump_1,45,,,2

--- a/approved/v93k_global/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_global/testflow/mfh.testflow.group/prb1.tf
@@ -13,21 +13,8 @@ tm_100:
   "output" = "None";
   "testName" = "Functional";
 tm_101:
-  "forceMode" = "VOLT";
-  "forceValue" = "3.8[V]";
-  "measureMode" = "PPMUpar";
-  "output" = "None";
-  "pinlist" = "@";
-  "ppmuClampHigh" = "0[V]";
-  "ppmuClampLow" = "0[V]";
-  "precharge" = "OFF";
-  "prechargeVoltage" = "0[V]";
-  "relaySwitchMode" = "DEFAULT(BBM)";
-  "settlingTime" = "0[s]";
-  "spmuClamp" = "0[A]";
-  "termination" = "OFF";
-  "testName" = "passLimit_uA_mV";
-  "testerState" = "CONNECTED";
+  "double" = "1.0";
+  "int" = "1";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";
@@ -160,6 +147,22 @@ tm_11:
   "output" = "None";
   "testName" = "Functional";
 tm_110:
+  "forceMode" = "VOLT";
+  "forceValue" = "3.8[V]";
+  "measureMode" = "PPMUpar";
+  "output" = "None";
+  "pinlist" = "@";
+  "ppmuClampHigh" = "0[V]";
+  "ppmuClampLow" = "0[V]";
+  "precharge" = "OFF";
+  "prechargeVoltage" = "0[V]";
+  "relaySwitchMode" = "DEFAULT(BBM)";
+  "settlingTime" = "0[s]";
+  "spmuClamp" = "0[A]";
+  "termination" = "OFF";
+  "testName" = "passLimit_uA_mV";
+  "testerState" = "CONNECTED";
+tm_111:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";
   "measureMode" = "PPMUpar";
@@ -475,26 +478,28 @@ tm_10:
 tm_100:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_101:
-  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
+  "Functional" = "":"NA":"":"NA":"":"":"";
 tm_102:
-  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
 tm_103:
-  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
 tm_104:
   "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_105:
-  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_106:
   "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_107:
-  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_108:
-  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
 tm_109:
-  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
 tm_11:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_110:
+  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
+tm_111:
   "passLimit_uA_mV" = "[1.0e-06, 2.0e-06, 3.0e-06]":"GE":"[4.0e-06, 5.0e-06]":"LE":"":"":"0";
 tm_12:
   "Functional" = "":"NA":"":"NA":"":"":"";
@@ -700,7 +705,7 @@ tm_10:
 tm_100:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_101:
-  testmethod_class = "dc_tml.DcTest.GeneralPMU";
+  testmethod_class = "MyTypeCheck.MyHashExampleClass";
 tm_102:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_103:
@@ -720,6 +725,8 @@ tm_109:
 tm_11:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_110:
+  testmethod_class = "dc_tml.DcTest.GeneralPMU";
+tm_111:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_12:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
@@ -1413,70 +1420,70 @@ meas_read_pump_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_102;
+  override_testf = tm_103;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_2_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_103;
+  override_testf = tm_104;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_3_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_104;
+  override_testf = tm_105;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_4_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_105;
+  override_testf = tm_106;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_5_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_106;
+  override_testf = tm_107;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_6_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_107;
+  override_testf = tm_108;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_7_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_108;
+  override_testf = tm_109;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_101;
+  override_testf = tm_102;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_8_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_109;
+  override_testf = tm_110;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_9_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "meas_read_pump";
-  override_testf = tm_110;
+  override_testf = tm_111;
   site_control = "parallel:";
   site_match = 2;
 mixed_flag_check_864CE8F:
@@ -1660,6 +1667,12 @@ test_with_no_flags_864CE8F:
   override_testf = tm_97;
   site_control = "parallel:";
   site_match = 2;
+type_check_864CE8F:
+  local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
+  override = 1;
+  override_testf = tm_101;
+  site_control = "parallel:";
+  site_match = 2;
 xcvr_fs_vilvih_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
@@ -1712,6 +1725,7 @@ test_flow
        @G100_864CE8F_RAN = -1;
        @DEEP_TEST_864CE8F_FAILED = -1;
     }, open,"Init Flow Control Vars", ""
+    print_dl("PRB1 Test Flow Version 00001 - do not copy me to approved!");
     {
        run_and_branch(program_ckbd_864CE8F)
        then
@@ -2218,6 +2232,7 @@ test_flow
        print_dl("force_serial test method parameter can be programmed");
        run(force_serial_true_test_864CE8F);
        run(force_serial_false_test_864CE8F);
+       run(type_check_864CE8F);
     }, open,"prb1_main", ""
     {
        run_and_branch(meas_read_pump_864CE8F)

--- a/approved/v93k_multiport/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_multiport/testflow/mfh.testflow.group/prb1.tf
@@ -13,21 +13,8 @@ tm_100:
   "output" = "None";
   "testName" = "Functional";
 tm_101:
-  "forceMode" = "VOLT";
-  "forceValue" = "3.8[V]";
-  "measureMode" = "PPMUpar";
-  "output" = "None";
-  "pinlist" = "@";
-  "ppmuClampHigh" = "0[V]";
-  "ppmuClampLow" = "0[V]";
-  "precharge" = "OFF";
-  "prechargeVoltage" = "0[V]";
-  "relaySwitchMode" = "DEFAULT(BBM)";
-  "settlingTime" = "0[s]";
-  "spmuClamp" = "0[A]";
-  "termination" = "OFF";
-  "testName" = "passLimit_uA_mV";
-  "testerState" = "CONNECTED";
+  "double" = "1.0";
+  "int" = "1";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";
@@ -160,6 +147,22 @@ tm_11:
   "output" = "None";
   "testName" = "Functional";
 tm_110:
+  "forceMode" = "VOLT";
+  "forceValue" = "3.8[V]";
+  "measureMode" = "PPMUpar";
+  "output" = "None";
+  "pinlist" = "@";
+  "ppmuClampHigh" = "0[V]";
+  "ppmuClampLow" = "0[V]";
+  "precharge" = "OFF";
+  "prechargeVoltage" = "0[V]";
+  "relaySwitchMode" = "DEFAULT(BBM)";
+  "settlingTime" = "0[s]";
+  "spmuClamp" = "0[A]";
+  "termination" = "OFF";
+  "testName" = "passLimit_uA_mV";
+  "testerState" = "CONNECTED";
+tm_111:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";
   "measureMode" = "PPMUpar";
@@ -475,26 +478,28 @@ tm_10:
 tm_100:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_101:
-  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
+  "Functional" = "":"NA":"":"NA":"":"":"";
 tm_102:
-  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"":"NA":"":"":"0";
 tm_103:
-  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
+  "passLimit_uA_mV" = "":"NA":"45":"LE":"":"":"0";
 tm_104:
   "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_105:
-  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
+  "passLimit_uA_mV" = "35":"GE":"45":"LE":"":"":"0";
 tm_106:
   "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_107:
-  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.035":"GE":"0.045":"LE":"":"":"0";
 tm_108:
-  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"2000":"LE":"":"":"0";
 tm_109:
-  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
+  "passLimit_uA_mV" = "0.01":"GE":"_some_spec":"LE":"":"":"0";
 tm_11:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_110:
+  "passLimit_uA_mV" = "":"NA":"[1, 2]":"LE":"":"":"0";
+tm_111:
   "passLimit_uA_mV" = "[1.0e-06, 2.0e-06, 3.0e-06]":"GE":"[4.0e-06, 5.0e-06]":"LE":"":"":"0";
 tm_12:
   "Functional" = "":"NA":"":"NA":"":"":"";
@@ -700,7 +705,7 @@ tm_10:
 tm_100:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_101:
-  testmethod_class = "dc_tml.DcTest.GeneralPMU";
+  testmethod_class = "MyTypeCheck.MyHashExampleClass";
 tm_102:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_103:
@@ -720,6 +725,8 @@ tm_109:
 tm_11:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
 tm_110:
+  testmethod_class = "dc_tml.DcTest.GeneralPMU";
+tm_111:
   testmethod_class = "dc_tml.DcTest.GeneralPMU";
 tm_12:
   testmethod_class = "ac_tml.AcTest.FunctionalTest";
@@ -1413,70 +1420,70 @@ meas_read_pump_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_102;
+  override_testf = tm_103;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_2_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_103;
+  override_testf = tm_104;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_3_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_104;
+  override_testf = tm_105;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_4_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_105;
+  override_testf = tm_106;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_5_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_106;
+  override_testf = tm_107;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_6_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_107;
+  override_testf = tm_108;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_7_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_108;
+  override_testf = tm_109;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_101;
+  override_testf = tm_102;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_8_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_109;
+  override_testf = tm_110;
   site_control = "parallel:";
   site_match = 2;
 meas_read_pump_9_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
   override_seqlbl = "mPort_meas_read_pump";
-  override_testf = tm_110;
+  override_testf = tm_111;
   site_control = "parallel:";
   site_match = 2;
 mixed_flag_check_864CE8F:
@@ -1660,6 +1667,12 @@ test_with_no_flags_864CE8F:
   override_testf = tm_97;
   site_control = "parallel:";
   site_match = 2;
+type_check_864CE8F:
+  local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
+  override = 1;
+  override_testf = tm_101;
+  site_control = "parallel:";
+  site_match = 2;
 xcvr_fs_vilvih_1_864CE8F:
   local_flags = output_on_pass, output_on_fail, value_on_pass, value_on_fail, per_pin_on_pass, per_pin_on_fail;
   override = 1;
@@ -1712,6 +1725,7 @@ test_flow
        @G100_864CE8F_RAN = -1;
        @DEEP_TEST_864CE8F_FAILED = -1;
     }, open,"Init Flow Control Vars", ""
+    print_dl("PRB1 Test Flow Version 00001 - do not copy me to approved!");
     {
        run_and_branch(program_ckbd_864CE8F)
        then
@@ -2218,6 +2232,7 @@ test_flow
        print_dl("force_serial test method parameter can be programmed");
        run(force_serial_true_test_864CE8F);
        run(force_serial_false_test_864CE8F);
+       run(type_check_864CE8F);
     }, open,"prb1_main", ""
     {
        run_and_branch(meas_read_pump_864CE8F)

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -271,17 +271,20 @@ flow PRB1_MAIN {
                 param_list_strings = #["E1", "E2"];
                 param_list_classes = #[E1, E2];
                 param_name1[my_param_name1] = {
-                    param_name0 = 1;
+                    param_name_int = 1;
+                    param_name_double = 1.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
                 };
                 param_name1[my_param_name2] = {
-                    param_name0 = 2;
+                    param_name_int = 2;
+                    param_name_double = 2.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
                 };
                 param_name1[my_param_name3] = {
-                    param_name0 = 3;
+                    param_name_int = 3;
+                    param_name_double = 0.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
                 };
@@ -289,18 +292,18 @@ flow PRB1_MAIN {
             nestedHashParameter2[my_param_name4] = {
                 param_name0 = "goodbye";
                 param_name1[param0] = {
-                    param_name0 = 0;
+                    param_name_int = 0;
                 };
             };
             nestedHashParameter2[my_param_name5] = {
                 param_name0 = "goodbye forever";
                 param_name1[param0] = {
-                    param_name0 = 0;
+                    param_name_int = 0;
                 };
             };
             pinList = "";
             prechargeVoltage = "0[V]";
-            samples = 1;
+            samples = 2;
             settlingTime = "0[s]";
             testName = "HashExample";
             testerState = "CONNECTED";
@@ -551,6 +554,11 @@ flow PRB1_MAIN {
             measurement.specification = setupRef(OrigenTesters.specs.specs.Nominal);
             output = "None";
             testName = "Functional";
+        }
+
+        suite type_check calls myTypeCheck.MyHashExampleClass {
+            double = 1.0;
+            int = 1;
         }
 
         suite xcvr_fs_vilvih calls ac_tml.AcTest.FunctionalTest {
@@ -845,5 +853,6 @@ flow PRB1_MAIN {
         DEEP_TEST_FAILED = DEEP_NESTED.DEEP_TEST_FAILED;
         test_with_no_flags.execute();
         test_with_flags.execute();
+        type_check.execute();
     }
 }

--- a/approved/v93k_smt8/OrigenTesters/limits/Main.PRB1_Tests.csv
+++ b/approved/v93k_smt8/OrigenTesters/limits/Main.PRB1_Tests.csv
@@ -106,6 +106,7 @@ PRB1_MAIN.cc_test_2,cc_test_2,7002,cc_test_2,0,0,,
 PRB1_MAIN.DEEP_NESTED.deep_test,deep_test,,deep_test,0,0,,
 PRB1_MAIN.test_with_no_flags,test_with_no_flags,6020,test_with_no_flags,0,0,,
 PRB1_MAIN.test_with_flags,test_with_flags,6030,test_with_flags,0,0,,
+PRB1_MAIN.type_check,type_check,6035,type_check,0,0,,
 TEST.program_ckbd,program_ckbd,40000,program_ckbd,0,0,,1100
 TEST.meas_read_pump,meas_read_pump,40005,meas_read_pump,,35,,2
 TEST.meas_read_pump_1,meas_read_pump_1,40010,meas_read_pump_1,45,,,2

--- a/lib/origen_testers/smartest_based_tester/base/test_method.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_method.rb
@@ -132,8 +132,10 @@ module OrigenTesters
             "#{val}[Hz]"
           when :string
             val.to_s
-          when :integer, :double
-            val
+          when :integer
+            val.to_i
+          when :double
+            val.to_f
           when :boolean
             # Check for valid values
             if [0, 1, true, false, 'true', 'false'].include?(val)

--- a/lib/origen_testers/test/interface.rb
+++ b/lib/origen_testers/test/interface.rb
@@ -61,7 +61,8 @@ module OrigenTesters
                     param_list_strings: [:list_strings, %w(E1 E2)],
                     param_list_classes: [:list_classes, %w(E1 E2)],
                     param_name1:        [{
-                      param_name0:        [:integer, 0],
+                      param_name_int:     [:integer, 0],
+                      param_name_double:  [:double,  0],
                       param_list_strings: [:list_strings, %w(E1 E2)],
                       param_list_classes: [:list_classes, %w(E1 E2)]
                     }]
@@ -69,9 +70,22 @@ module OrigenTesters
                   'nestedHashParameter2': [{
                     param_name0: [:string, ''],
                     param_name1: [{
-                      param_name0: [:integer, 0]
+                      param_name_int: [:integer, 0]
                     }]
                   }]
+                }
+        add_tml :my_type_check,
+                class_name:   'MyTypeCheck',
+
+                # Here is a test definition.
+                # The identifier should be lower-cased and underscored, in-keeping with Ruby naming conventions.
+                # By default the class name will be the camel-cased version of this identifier, so 'myTest' in
+                # this case.
+                my_type_check_test: {
+                  # [OPTIONAL] The C++ test method class name can be overridden from the default like this:
+                  class_name: 'MyHashExampleClass',
+                  int:        [:integer, 1],
+                  double:     [:double,  1.0],
                 }
       end
 
@@ -279,6 +293,22 @@ module OrigenTesters
         end
       end
 
+
+      def double_int_type_check(name, options = {})
+        number = options[:number]
+        if tester.v93k?
+          block_loop(name, options) do |block, i|
+            options[:number] = number + i if number && i
+            tm = test_methods.my_type_check.my_type_check_test
+            tm.int    = '1'
+            tm.double = '1.0'
+            ts = test_suites.run(name, options)
+            ts.test_method = tm
+            flow.test ts, options
+          end
+        end
+      end
+
       def my_hash_test(name, options = {})
         number = options[:number]
 
@@ -294,13 +324,15 @@ module OrigenTesters
                 param_name0: 'hello',
                 param_name1: {
                   my_param_name1: {
-                    param_name0: 1
+                    param_name_int:    '1',
+                    param_name_double: '1.0'
                   },
                   my_param_name2: {
-                    param_name0: 2
+                    param_name_int:    2,
+                    param_name_double: 2.0,
                   },
                   my_param_name3: {
-                    param_name0: 3
+                    param_name_int: 3
                   }
                 }
               }
@@ -313,6 +345,7 @@ module OrigenTesters
                 param_name0: 'goodbye forever'
               }
             }
+            tm.samples = '2'
             ts = test_suites.run(name, options)
             ts.test_method = tm
             ts.spec = options.delete(:pin_levels) if options[:pin_levels]

--- a/lib/origen_testers/test/interface.rb
+++ b/lib/origen_testers/test/interface.rb
@@ -75,7 +75,7 @@ module OrigenTesters
                   }]
                 }
         add_tml :my_type_check,
-                class_name:   'MyTypeCheck',
+                class_name:         'MyTypeCheck',
 
                 # Here is a test definition.
                 # The identifier should be lower-cased and underscored, in-keeping with Ruby naming conventions.
@@ -85,7 +85,7 @@ module OrigenTesters
                   # [OPTIONAL] The C++ test method class name can be overridden from the default like this:
                   class_name: 'MyHashExampleClass',
                   int:        [:integer, 1],
-                  double:     [:double,  1.0],
+                  double:     [:double,  1.0]
                 }
       end
 
@@ -293,7 +293,6 @@ module OrigenTesters
         end
       end
 
-
       def double_int_type_check(name, options = {})
         number = options[:number]
         if tester.v93k?
@@ -329,7 +328,7 @@ module OrigenTesters
                   },
                   my_param_name2: {
                     param_name_int:    2,
-                    param_name_double: 2.0,
+                    param_name_double: 2.0
                   },
                   my_param_name3: {
                     param_name_int: 3

--- a/program/components/_prb1_main.rb
+++ b/program/components/_prb1_main.rb
@@ -257,4 +257,6 @@ Flow.create do |options|
     func :force_serial_false_test, force_serial: false
   end
 
+  double_int_type_check :type_check, number: 6035
+
 end


### PR DESCRIPTION
SMT8 requires the types to be maintained for the parameters. Without forcing the type in the parameters, providing a string to integers and doubles will show up as strings in the final output.