### PR TITLE
Ruby Flow keyword patch

### DIFF
--- a/lib/origen_testers/atp/flow_api.rb
+++ b/lib/origen_testers/atp/flow_api.rb
@@ -9,7 +9,7 @@ module OrigenTesters::ATP
     end
 
     ([:test, :bin, :pass, :continue, :cz, :log, :sub_test, :volatile, :add_global_flag, :set_flag, :unset_flag, :add_flag, :set, :enable, :disable, :render,
-      :context_changed?, :ids, :describe_bin, :describe_softbin, :describe_soft_bin, :loop, :add_auxiliary_flow] +
+      :context_changed?, :ids, :describe_bin, :describe_softbin, :describe_soft_bin, :add_auxiliary_flow] +
       OrigenTesters::ATP::Flow::CONDITION_KEYS.keys + OrigenTesters::ATP::Flow::RELATIONAL_OPERATORS).each do |method|
       define_method method do |*args, &block|
         options = args.pop if args.last.is_a?(Hash)
@@ -22,6 +22,19 @@ module OrigenTesters::ATP
     end
 
     alias_method :logprint, :log
+
+    def loop(*args, &block)
+      if args.empty? && !Origen.interface_loaded?
+        super(&block)
+      else
+        options = args.pop if args.last.is_a?(Hash)
+        options ||= {}
+        add_meta!(options) if respond_to?(:add_meta!, true)
+        add_description!(options) if respond_to?(:add_description!, true)
+        args << options
+        atp.send(:loop, *args, &block)
+      end
+    end
 
     def lo_limit(value, options)
       {


### PR DESCRIPTION
Update flow_api wrapper method of flow.loop to **handle case where interface has not been created yet**