### PR TITLE
Fix the period alias on nested parameters

### DIFF
--- a/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -270,23 +270,27 @@ flow PRB1_MAIN {
                 param_name0 = "hello";
                 param_list_strings = #["E1", "E2"];
                 param_list_classes = #[E1, E2];
+                param_group.param0 = "test_group";
                 param_name1[my_param_name1] = {
                     param_name_int = 1;
                     param_name_double = 1.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
+                    param_group.param1 = "test_nested_group";
                 };
                 param_name1[my_param_name2] = {
                     param_name_int = 2;
                     param_name_double = 2.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
+                    param_group.param1 = "";
                 };
                 param_name1[my_param_name3] = {
                     param_name_int = 3;
                     param_name_double = 0.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
+                    param_group.param1 = "";
                 };
             };
             nestedHashParameter2[my_param_name4] = {

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -270,23 +270,27 @@ flow PRB1_MAIN {
                 param_name0 = "hello";
                 param_list_strings = #["E1", "E2"];
                 param_list_classes = #[E1, E2];
+                param_group.param0 = "test_group";
                 param_name1[my_param_name1] = {
                     param_name_int = 1;
                     param_name_double = 1.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
+                    param_group.param1 = "test_nested_group";
                 };
                 param_name1[my_param_name2] = {
                     param_name_int = 2;
                     param_name_double = 2.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
+                    param_group.param1 = "";
                 };
                 param_name1[my_param_name3] = {
                     param_name_int = 3;
                     param_name_double = 0.0;
                     param_list_strings = #["E1", "E2"];
                     param_list_classes = #[E1, E2];
+                    param_group.param1 = "";
                 };
             };
             nestedHashParameter2[my_param_name4] = {

--- a/lib/origen_testers/atp/flow.rb
+++ b/lib/origen_testers/atp/flow.rb
@@ -626,37 +626,32 @@ module OrigenTesters::ATP
     end
 
     def loop(*args, &block)
-      if args[0].except(:source_file, :source_line_number).empty?
-        # not a flow api call, just a loop block
-        super(&block)
-      else
-        unless args[0].keys.include?(:from) && args[0].keys.include?(:to)
-          fail 'Loop must specify :from, :to'
+      unless args[0].keys.include?(:from) && args[0].keys.include?(:to)
+        fail 'Loop must specify :from, :to'
+      end
+      # assume 1 if :step not provided
+      unless args[0].keys.include?(:step)
+        args[0][:step] = 1
+      end
+      # assume 1 if :test_num_inc not provided
+      unless args[0].keys.include?(:test_num_inc)
+        args[0][:test_num_inc] = 1
+      end
+      # Add node for set of flag to be used for loop
+      unless args[0][:var].nil?
+        unless tester.smt8?
+          set(args[0][:var], 0)
         end
-        # assume 1 if :step not provided
-        unless args[0].keys.include?(:step)
-          args[0][:step] = 1
-        end
-        # assume 1 if :test_num_inc not provided
-        unless args[0].keys.include?(:test_num_inc)
-          args[0][:test_num_inc] = 1
-        end
-        # Add node for set of flag to be used for loop
-        unless args[0][:var].nil?
-          unless tester.smt8?
-            set(args[0][:var], 0)
-          end
-        end
-        extract_meta!(options) do
-          apply_conditions(options) do
-            # always pass 5-element array to loop node to simplify downstream parser
-            #   element, 'var', will be nil if not specified by loop call
-            params = [args[0][:from], args[0][:to], args[0][:step], args[0][:var], args[0][:test_num_inc]]
+      end
+      extract_meta!(options) do
+        apply_conditions(options) do
+          # always pass 5-element array to loop node to simplify downstream parser
+          #   element, 'var', will be nil if not specified by loop call
+          params = [args[0][:from], args[0][:to], args[0][:step], args[0][:var], args[0][:test_num_inc]]
 
-            node = n(:loop, params)
-            node = append_to(node) { block.call }
-            node
-          end
+          node = n(:loop, params)
+          node = append_to(node) { block.call }
+          node
         end
       end
     end

--- a/lib/origen_testers/atp/flow_api.rb
+++ b/lib/origen_testers/atp/flow_api.rb
@@ -24,7 +24,7 @@ module OrigenTesters::ATP
     alias_method :logprint, :log
 
     def loop(*args, &block)
-      if args.empty? && !Origen.interface_loaded?
+      if args.empty?
         super(&block)
       else
         options = args.pop if args.last.is_a?(Hash)

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/test_suite.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/test_suite.rb
@@ -124,7 +124,7 @@ module OrigenTesters
               # Guarentee hash is using all symbol keys
               # Since we cannot guarentee ruby version is greater than 2.5, we have to use an older syntax to
               value_hash = value_hash.inject({}) { |memo, (k, v)| memo[k.to_sym] = v; memo }
-              nested_key = nested_param.first.to_sym
+              nested_key = nested_param.first.to_s.gsub('.', '_').to_sym
               nested_key_underscore = nested_key.to_s.underscore.to_sym
               nested_params_accepted_keys << nested_key
               nested_params_accepted_keys << nested_key_underscore

--- a/lib/origen_testers/test/interface.rb
+++ b/lib/origen_testers/test/interface.rb
@@ -57,15 +57,15 @@ module OrigenTesters
                   'hashParameter':        [{ param_name0: [:string, 'NO'], param_name1: [:integer, 0] }],
                   'hashParameter2':       [{ param_name0: [:string, 'NO'], param_name1: [:integer, 0] }],
                   'nestedHashParameter':  [{
-                    param_name0:        [:string, ''],
-                    param_list_strings: [:list_strings, %w(E1 E2)],
-                    param_list_classes: [:list_classes, %w(E1 E2)],
+                    param_name0:          [:string, ''],
+                    param_list_strings:   [:list_strings, %w(E1 E2)],
+                    param_list_classes:   [:list_classes, %w(E1 E2)],
                     'param_group.param0': [:string, ''],
-                    param_name1:        [{
-                      param_name_int:     [:integer, 0],
-                      param_name_double:  [:double,  0],
-                      param_list_strings: [:list_strings, %w(E1 E2)],
-                      param_list_classes: [:list_classes, %w(E1 E2)],
+                    param_name1:          [{
+                      param_name_int:       [:integer, 0],
+                      param_name_double:    [:double,  0],
+                      param_list_strings:   [:list_strings, %w(E1 E2)],
+                      param_list_classes:   [:list_classes, %w(E1 E2)],
                       'param_group.param1': [:string, '']
                     }]
                   }],
@@ -322,12 +322,12 @@ module OrigenTesters
             }
             tm.nestedHashParameter = {
               my_param_name0: {
-                param_name0: 'hello',
+                param_name0:        'hello',
                 param_group_param0: 'test_group',
-                param_name1: {
+                param_name1:        {
                   my_param_name1: {
-                    param_name_int:    '1',
-                    param_name_double: '1.0',
+                    param_name_int:     '1',
+                    param_name_double:  '1.0',
                     param_group_param1: 'test_nested_group'
                   },
                   my_param_name2: {

--- a/lib/origen_testers/test/interface.rb
+++ b/lib/origen_testers/test/interface.rb
@@ -60,11 +60,13 @@ module OrigenTesters
                     param_name0:        [:string, ''],
                     param_list_strings: [:list_strings, %w(E1 E2)],
                     param_list_classes: [:list_classes, %w(E1 E2)],
+                    'param_group.param0': [:string, ''],
                     param_name1:        [{
                       param_name_int:     [:integer, 0],
                       param_name_double:  [:double,  0],
                       param_list_strings: [:list_strings, %w(E1 E2)],
-                      param_list_classes: [:list_classes, %w(E1 E2)]
+                      param_list_classes: [:list_classes, %w(E1 E2)],
+                      'param_group.param1': [:string, '']
                     }]
                   }],
                   'nestedHashParameter2': [{
@@ -321,10 +323,12 @@ module OrigenTesters
             tm.nestedHashParameter = {
               my_param_name0: {
                 param_name0: 'hello',
+                param_group_param0: 'test_group',
                 param_name1: {
                   my_param_name1: {
                     param_name_int:    '1',
-                    param_name_double: '1.0'
+                    param_name_double: '1.0',
+                    param_group_param1: 'test_nested_group'
                   },
                   my_param_name2: {
                     param_name_int:    2,


### PR DESCRIPTION
The alias handling for nested parameters was not matching the other core locations. I had to update here to align with expected key handling.