### PR TITLE
Feature/smt8 ast call causes incorrect finalized

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base/flow.rb
+++ b/lib/origen_testers/smartest_based_tester/base/flow.rb
@@ -188,6 +188,9 @@ module OrigenTesters
           if smt8?
             return unless top_level? || options[:called_by_top_level]
             super
+            # Refresh the ast before finalized gets set to true
+            # If ast gets called by the user the finalized flag will lock it to the incorrect value
+            ast
             @finalized = true
             # All flows have now been executed and the top-level contains the final AST.
             # The AST contained in each child flow may not be complete since it has not been subject to the

--- a/templates/origen_guides/program/flowapi.md.erb
+++ b/templates/origen_guides/program/flowapi.md.erb
@@ -375,6 +375,7 @@ end
 Indicating step value is optional, default is 1.
 
 These loops can also be nested:
+
 ~~~ruby
 loop from: 0, to: 9, step: 2, var: '$LOOP_VARIABLE1'do
   loop from: 1, to: 10, step: 1, var: '$LOOP_VARIABLE2' do
@@ -386,6 +387,7 @@ end
 ~~~
 
 You can also indicate a test number increment if desired (default is 1):
+
 ~~~ruby
 loop from: 0, to: 5, var: '$LOOP_VARIABLE', test_num_inc: 2 do
     func :test_myloop3, number: 56200
@@ -393,6 +395,7 @@ end
 ~~~
 
 You can also provide a variable starting point:
+
 ~~~ruby
 loop from: '$TEST_VARIABLE', to: 5, var: '$LOOP_VARIABLE' do
     func :test_myloop6, number: 56600


### PR DESCRIPTION
If ast is called before the @finalized is set in the flow class, there is a possibility the final ast will have incomplete information.