### PR TITLE
Convert updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Development dependencies
 gem 'byebug', "~>11"
 gem 'ripper-tags'
+gem 'origen', '0.60.7'		# tmp - prevent 100's of new lint errors
 gem 'origen_arm_debug', '0.4.3'
 gem 'yard-activesupport-concern'
 gem 'origen_jtag', '>= 0.12.0'

--- a/lib/origen_testers/decompiler/nodes.rb
+++ b/lib/origen_testers/decompiler/nodes.rb
@@ -103,6 +103,8 @@ module OrigenTesters
         alias_method :pinlist, :pins
 
         def initialize(pins:, context:)
+          # remove trailing formatting characters
+          pins = pins.map { |p| p.split(':').first }
           @pins = pins.map(&:strip).map(&:to_sym)
           super(context: context, type: :pinlist)
         end

--- a/lib/origen_testers/igxl_based_tester/decompiler/atp.rb
+++ b/lib/origen_testers/igxl_based_tester/decompiler/atp.rb
@@ -59,6 +59,8 @@ module OrigenTesters
             nodes_namespace::CommentBlock.new(context:  self,
                                               comments: raw_vector.split("\n")
                                              )
+          elsif raw_vector.strip.size == 0
+            nodes_namespace::CommentBlock.new(context: self, comments: ['// blank line replaced with comment by origen convert'])
           elsif raw_vector =~ Regexp.new('^\s*start_label')
             nodes_namespace::StartLabel.new(context:     self,
                                             start_label: raw_vector[raw_vector.index('start_label') + 11..-1].strip[0..-2]
@@ -69,7 +71,9 @@ module OrigenTesters
                                              label_type: contents[0],
                                              label_name: contents[1]
                                             )
-          elsif raw_vector =~ Regexp.new(':(?!(.*>))')
+          # original elsif for label was updated to avoid confusing origen's eol comments for a label
+          # elsif raw_vector =~ Regexp.new(':(?!(.*>))')
+          elsif raw_vector.split(';').first =~ Regexp.new(':(?!(.*>))')
             nodes_namespace::Label.new(context:    self,
                                        # Strip any whitespace from the vector and grab contents up to
                                        # the ':' symbol.


### PR DESCRIPTION
Various bug fixes for issues uncovered while running origen convert on ascii patterns from various sources:
    1) End of line comments that origen creates when generating with -v option cause the vector to be detected as a label
    2) Trailing ":S" on pin names needs to be removed (ex: JTAG:S, CLKS:S, etc.)
    3) Blank lines cause a run time error