### PR TITLE
SMT8 built-in shmoo element

### DIFF
--- a/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -593,6 +593,92 @@ flow PRB1_MAIN {
             testName = "Functional";
         }
 
+        shmoo shmoo_over_tf {
+            target = erase;
+            resultTitle = "shmooOverTF";
+        
+            axis [vcc] = {
+                resourceType = specVariable;
+                resourceName = "vcc";
+                range.start = 3;
+                range.stop = 5;
+                range.steps = 10;
+            };
+        }
+
+        shmoo shmoo_over_ts_1D {
+            target = test200_1;
+            resultTitle = "shmooOverTest";
+            executionOrder = horizontal;
+        
+            axis [axis1] = {
+                resourceType = specVariable;
+                resourceName = "vcc";
+                range.start = 3.0;
+                range.stop = 5.0;
+                range.steps = 10;
+            };
+        }
+
+        shmoo shmoo_over_ts_3D {
+            target = test200_2;
+        
+            axis [axis1] = {
+                resourceType = instrumentProperty;
+                resourceName = "vih";
+                range.relativePercentage.start = -0.01;
+                range.relativePercentage.stop = 0.01;
+                range.steps = 10;
+            };
+            axis [axis2] = {
+                resourceType = specVariable;
+                resourceName = "vcc";
+                range.start = 3;
+                range.stop = 5;
+                range.steps = 10;
+            };
+            axis [axis3] = {
+                resourceType = suiteParameter;
+                resourceName = "forceVoltage";
+                range.start = 4.8;
+                range.stop = 5.2;
+                range.steps = 10;
+            };
+        }
+
+        shmoo shmoo_over_ts_multiple_ts {
+            target = #[test200_1,test200_2];
+            resultTitle = "shmooOverMultiTS";
+        
+            axis [vih] = {
+                resourceType = instrumentProperty;
+                resourceName = "vih";
+                range.relativePercentage.start = -0.01;
+                range.relativePercentage.stop = 0.01;
+                range.steps = 10;
+            };
+        }
+
+        shmoo shmoo_with_tracking_para {
+            target = erase;
+            resultTitle = "shmooOverTF";
+        
+            axis [vcc] = {
+                resourceType = specVariable;
+                resourceName = "vcc";
+                range.start = 0.5;
+                range.stop = 3.5;
+                range.steps = 10;
+        
+                tracking [voh] = {
+                    resourceType = instrumentProperty;
+                    resourceName = "voh";
+                    range.relativeValue.start = 1;
+                    range.relativeValue.stop = 2;
+                };
+            };
+        }
+
         flow POWERDOWN calls testflow.POWERDOWN {}
         flow ERASE calls OrigenTesters.flows.prb1.prb1_main.ERASE { }
         flow PROGRAM_CKBD calls OrigenTesters.flows.prb1.prb1_main.PROGRAM_CKBD { }
@@ -873,5 +959,15 @@ flow PRB1_MAIN {
         test_with_no_flags.execute();
         test_with_flags.execute();
         type_check.execute();
+        println("shmoo test insertion works as expected, shmoo over test suite 1D");
+        shmoo_over_ts_1D.execute();
+        println("shmoo test insertion works as expected, shmoo over test suite 3D");
+        shmoo_over_ts_3D.execute();
+        println("shmoo test insertion works as expected, shmoo over multiple test suites");
+        shmoo_over_ts_multiple_ts.execute();
+        println("shmoo test insertion works as expected, shmoo over test flow");
+        shmoo_over_tf.execute();
+        println("shmoo test insertion works as expected, shmoo with tracking parameters");
+        shmoo_with_tracking_para.execute();
     }
 }

--- a/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -595,7 +595,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_over_tf {
-            target = erase;
+            target = 200MHZ_TESTS;
             resultTitle = "shmooOverTF";
         
             axis [vcc] = {
@@ -608,7 +608,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_over_ts_1D {
-            target = test200_1;
+            target = cc_test_0;
             resultTitle = "shmooOverTest";
             executionOrder = horizontal;
         
@@ -622,7 +622,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_over_ts_3D {
-            target = test200_2;
+            target = erase_all;
         
             axis [axis1] = {
                 resourceType = instrumentProperty;
@@ -648,7 +648,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_over_ts_multiple_ts {
-            target = #[test200_1,test200_2];
+            target = #[margin_read0_ckbd,margin_read1_ckbd];
             resultTitle = "shmooOverMultiTS";
         
             axis [vih] = {
@@ -661,7 +661,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_with_tracking_para {
-            target = erase;
+            target = ERASE;
             resultTitle = "shmooOverTF";
         
             axis [vcc] = {
@@ -965,14 +965,14 @@ flow PRB1_MAIN {
         println("shmoo test insertion works as expected, shmoo over test suite 1D");
         shmoo_over_ts_1D.execute();
         println("shmoo test insertion works as expected, shmoo over test suite 3D");
-        if (G200_FAILED == 1) {
+        if (DO_ERASE == 1) {
             shmoo_over_ts_3D.execute();
         } else {
         }
         println("shmoo test insertion works as expected, shmoo over multiple test suites");
         shmoo_over_ts_multiple_ts.execute();
         println("shmoo test insertion works as expected, shmoo over test flow");
-        if (DO_ERASE == 1) {
+        if (G200_FAILED == 1) {
             shmoo_over_tf.execute();
         } else {
         }

--- a/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -22,6 +22,7 @@ flow PRB1_MAIN {
     out ERASE_RAN_4_RAN = -1;
     out ERS_VFY_FAILED = -1;
     out G100_RAN = -1;
+    out G200_FAILED = -1;
 
     setup {
         suite another_not_p1_or_p2_test calls ac_tml.AcTest.FunctionalTest {
@@ -706,6 +707,7 @@ flow PRB1_MAIN {
         ERASE_RAN_2_RAN = -1;
         ERASE_RAN_3_RAN = -1;
         ERASE_RAN_4_RAN = -1;
+        G200_FAILED = -1;
 
         hash_example.execute();
         spec_override_example.execute();
@@ -928,6 +930,7 @@ flow PRB1_MAIN {
         println("Speed binning example bug from video 5");
         200MHZ_TESTS.execute();
         if (!200MHZ_TESTS.pass) {
+            G200_FAILED = 1;
             100MHZ_TESTS.execute();
             // 100MHZ_TESTS sub-flow output variables
             {
@@ -962,11 +965,17 @@ flow PRB1_MAIN {
         println("shmoo test insertion works as expected, shmoo over test suite 1D");
         shmoo_over_ts_1D.execute();
         println("shmoo test insertion works as expected, shmoo over test suite 3D");
-        shmoo_over_ts_3D.execute();
+        if (G200_FAILED == 1) {
+            shmoo_over_ts_3D.execute();
+        } else {
+        }
         println("shmoo test insertion works as expected, shmoo over multiple test suites");
         shmoo_over_ts_multiple_ts.execute();
         println("shmoo test insertion works as expected, shmoo over test flow");
-        shmoo_over_tf.execute();
+        if (DO_ERASE == 1) {
+            shmoo_over_tf.execute();
+        } else {
+        }
         println("shmoo test insertion works as expected, shmoo with tracking parameters");
         shmoo_with_tracking_para.execute();
     }

--- a/approved/v93k_flowgrouping/OrigenTesters/limits/Main.PRB1_Tests.csv
+++ b/approved/v93k_flowgrouping/OrigenTesters/limits/Main.PRB1_Tests.csv
@@ -107,6 +107,11 @@ PRB1_MAIN.DEEP_NESTED.deep_test,deep_test,,deep_test,0,0,,
 PRB1_MAIN.test_with_no_flags,test_with_no_flags,6020,test_with_no_flags,0,0,,
 PRB1_MAIN.test_with_flags,test_with_flags,6030,test_with_flags,0,0,,
 PRB1_MAIN.type_check,type_check,6035,type_check,0,0,,
+PRB1_MAIN.shmoo_over_ts_1D,shmoo_over_ts_1D,,shmoo_over_ts_1D,0,0,,
+PRB1_MAIN.shmoo_over_ts_3D,shmoo_over_ts_3D,,shmoo_over_ts_3D,0,0,,
+PRB1_MAIN.shmoo_over_ts_multiple_ts,shmoo_over_ts_multiple_ts,,shmoo_over_ts_multiple_ts,0,0,,
+PRB1_MAIN.shmoo_over_tf,shmoo_over_tf,,shmoo_over_tf,0,0,,
+PRB1_MAIN.shmoo_with_tracking_para,shmoo_with_tracking_para,,shmoo_with_tracking_para,0,0,,
 TEST.program_ckbd,program_ckbd,40000,program_ckbd,0,0,,1100
 TEST.meas_read_pump,meas_read_pump,40005,meas_read_pump,,35,,2
 TEST.meas_read_pump_1,meas_read_pump_1,40010,meas_read_pump_1,45,,,2

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -22,6 +22,7 @@ flow PRB1_MAIN {
     out ERASE_RAN_4_RAN = -1;
     out ERS_VFY_FAILED = -1;
     out G100_RAN = -1;
+    out G200_FAILED = -1;
 
     setup {
         suite another_not_p1_or_p2_test calls ac_tml.AcTest.FunctionalTest {
@@ -706,6 +707,7 @@ flow PRB1_MAIN {
         ERASE_RAN_2_RAN = -1;
         ERASE_RAN_3_RAN = -1;
         ERASE_RAN_4_RAN = -1;
+        G200_FAILED = -1;
 
         hash_example.execute();
         spec_override_example.execute();
@@ -919,6 +921,7 @@ flow PRB1_MAIN {
         println("Speed binning example bug from video 5");
         200MHZ_TESTS.execute();
         if (!200MHZ_TESTS.pass) {
+            G200_FAILED = 1;
             100MHZ_TESTS.execute();
             G100_RAN = 100MHZ_TESTS.G100_RAN;
         }
@@ -947,11 +950,17 @@ flow PRB1_MAIN {
         println("shmoo test insertion works as expected, shmoo over test suite 1D");
         shmoo_over_ts_1D.execute();
         println("shmoo test insertion works as expected, shmoo over test suite 3D");
-        shmoo_over_ts_3D.execute();
+        if (G200_FAILED == 1) {
+            shmoo_over_ts_3D.execute();
+        } else {
+        }
         println("shmoo test insertion works as expected, shmoo over multiple test suites");
         shmoo_over_ts_multiple_ts.execute();
         println("shmoo test insertion works as expected, shmoo over test flow");
-        shmoo_over_tf.execute();
+        if (DO_ERASE == 1) {
+            shmoo_over_tf.execute();
+        } else {
+        }
         println("shmoo test insertion works as expected, shmoo with tracking parameters");
         shmoo_with_tracking_para.execute();
     }

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -595,7 +595,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_over_tf {
-            target = erase;
+            target = 200MHZ_TESTS;
             resultTitle = "shmooOverTF";
         
             axis [vcc] = {
@@ -608,7 +608,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_over_ts_1D {
-            target = test200_1;
+            target = cc_test_0;
             resultTitle = "shmooOverTest";
             executionOrder = horizontal;
         
@@ -622,7 +622,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_over_ts_3D {
-            target = test200_2;
+            target = erase_all;
         
             axis [axis1] = {
                 resourceType = instrumentProperty;
@@ -648,7 +648,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_over_ts_multiple_ts {
-            target = #[test200_1,test200_2];
+            target = #[margin_read0_ckbd,margin_read1_ckbd];
             resultTitle = "shmooOverMultiTS";
         
             axis [vih] = {
@@ -661,7 +661,7 @@ flow PRB1_MAIN {
         }
 
         shmoo shmoo_with_tracking_para {
-            target = erase;
+            target = ERASE;
             resultTitle = "shmooOverTF";
         
             axis [vcc] = {
@@ -950,14 +950,14 @@ flow PRB1_MAIN {
         println("shmoo test insertion works as expected, shmoo over test suite 1D");
         shmoo_over_ts_1D.execute();
         println("shmoo test insertion works as expected, shmoo over test suite 3D");
-        if (G200_FAILED == 1) {
+        if (DO_ERASE == 1) {
             shmoo_over_ts_3D.execute();
         } else {
         }
         println("shmoo test insertion works as expected, shmoo over multiple test suites");
         shmoo_over_ts_multiple_ts.execute();
         println("shmoo test insertion works as expected, shmoo over test flow");
-        if (DO_ERASE == 1) {
+        if (G200_FAILED == 1) {
             shmoo_over_tf.execute();
         } else {
         }

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -593,6 +593,92 @@ flow PRB1_MAIN {
             testName = "Functional";
         }
 
+        shmoo shmoo_over_tf {
+            target = erase;
+            resultTitle = "shmooOverTF";
+        
+            axis [vcc] = {
+                resourceType = specVariable;
+                resourceName = "vcc";
+                range.start = 3;
+                range.stop = 5;
+                range.steps = 10;
+            };
+        }
+
+        shmoo shmoo_over_ts_1D {
+            target = test200_1;
+            resultTitle = "shmooOverTest";
+            executionOrder = horizontal;
+        
+            axis [axis1] = {
+                resourceType = specVariable;
+                resourceName = "vcc";
+                range.start = 3.0;
+                range.stop = 5.0;
+                range.steps = 10;
+            };
+        }
+
+        shmoo shmoo_over_ts_3D {
+            target = test200_2;
+        
+            axis [axis1] = {
+                resourceType = instrumentProperty;
+                resourceName = "vih";
+                range.relativePercentage.start = -0.01;
+                range.relativePercentage.stop = 0.01;
+                range.steps = 10;
+            };
+            axis [axis2] = {
+                resourceType = specVariable;
+                resourceName = "vcc";
+                range.start = 3;
+                range.stop = 5;
+                range.steps = 10;
+            };
+            axis [axis3] = {
+                resourceType = suiteParameter;
+                resourceName = "forceVoltage";
+                range.start = 4.8;
+                range.stop = 5.2;
+                range.steps = 10;
+            };
+        }
+
+        shmoo shmoo_over_ts_multiple_ts {
+            target = #[test200_1,test200_2];
+            resultTitle = "shmooOverMultiTS";
+        
+            axis [vih] = {
+                resourceType = instrumentProperty;
+                resourceName = "vih";
+                range.relativePercentage.start = -0.01;
+                range.relativePercentage.stop = 0.01;
+                range.steps = 10;
+            };
+        }
+
+        shmoo shmoo_with_tracking_para {
+            target = erase;
+            resultTitle = "shmooOverTF";
+        
+            axis [vcc] = {
+                resourceType = specVariable;
+                resourceName = "vcc";
+                range.start = 0.5;
+                range.stop = 3.5;
+                range.steps = 10;
+        
+                tracking [voh] = {
+                    resourceType = instrumentProperty;
+                    resourceName = "voh";
+                    range.relativeValue.start = 1;
+                    range.relativeValue.stop = 2;
+                };
+            };
+        }
+
         flow POWERDOWN calls testflow.POWERDOWN {}
         flow ERASE calls OrigenTesters.flows.prb1.prb1_main.ERASE { }
         flow PROGRAM_CKBD calls OrigenTesters.flows.prb1.prb1_main.PROGRAM_CKBD { }
@@ -858,5 +944,15 @@ flow PRB1_MAIN {
         test_with_no_flags.execute();
         test_with_flags.execute();
         type_check.execute();
+        println("shmoo test insertion works as expected, shmoo over test suite 1D");
+        shmoo_over_ts_1D.execute();
+        println("shmoo test insertion works as expected, shmoo over test suite 3D");
+        shmoo_over_ts_3D.execute();
+        println("shmoo test insertion works as expected, shmoo over multiple test suites");
+        shmoo_over_ts_multiple_ts.execute();
+        println("shmoo test insertion works as expected, shmoo over test flow");
+        shmoo_over_tf.execute();
+        println("shmoo test insertion works as expected, shmoo with tracking parameters");
+        shmoo_with_tracking_para.execute();
     }
 }

--- a/approved/v93k_smt8/OrigenTesters/limits/Main.PRB1_Tests.csv
+++ b/approved/v93k_smt8/OrigenTesters/limits/Main.PRB1_Tests.csv
@@ -107,6 +107,11 @@ PRB1_MAIN.DEEP_NESTED.deep_test,deep_test,,deep_test,0,0,,
 PRB1_MAIN.test_with_no_flags,test_with_no_flags,6020,test_with_no_flags,0,0,,
 PRB1_MAIN.test_with_flags,test_with_flags,6030,test_with_flags,0,0,,
 PRB1_MAIN.type_check,type_check,6035,type_check,0,0,,
+PRB1_MAIN.shmoo_over_ts_1D,shmoo_over_ts_1D,,shmoo_over_ts_1D,0,0,,
+PRB1_MAIN.shmoo_over_ts_3D,shmoo_over_ts_3D,,shmoo_over_ts_3D,0,0,,
+PRB1_MAIN.shmoo_over_ts_multiple_ts,shmoo_over_ts_multiple_ts,,shmoo_over_ts_multiple_ts,0,0,,
+PRB1_MAIN.shmoo_over_tf,shmoo_over_tf,,shmoo_over_tf,0,0,,
+PRB1_MAIN.shmoo_with_tracking_para,shmoo_with_tracking_para,,shmoo_with_tracking_para,0,0,,
 TEST.program_ckbd,program_ckbd,40000,program_ckbd,0,0,,1100
 TEST.meas_read_pump,meas_read_pump,40005,meas_read_pump,,35,,2
 TEST.meas_read_pump_1,meas_read_pump_1,40010,meas_read_pump_1,45,,,2

--- a/lib/origen_testers/smartest_based_tester/base/flow.rb
+++ b/lib/origen_testers/smartest_based_tester/base/flow.rb
@@ -241,6 +241,9 @@ module OrigenTesters
           end
           test_suites.finalize
           test_methods.finalize
+          if smt8?
+            shmoo_tests.finalize
+          end
           if tester.create_limits_file && top_level?
             render_limits_file
           end

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/flow.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/flow.rb
@@ -10,6 +10,8 @@ module OrigenTesters
           test_suite = node.find(:object).to_a[0]
           if test_suite.is_a?(String)
             name = test_suite
+          elsif test_suite.is_a?(ShmooTest)
+            name = test_suite.name
           else
             name = test_suite.name
             test_method = test_suite.test_method
@@ -185,6 +187,10 @@ module OrigenTesters
           @sub_flows || {}
         end
 
+        def shmoo_tests
+          @shmoo_tests ||= platform::ShmooTests.new(self)
+        end
+
         def auxiliary_flows
           @auxiliary_flows || {}
         end
@@ -223,17 +229,17 @@ module OrigenTesters
           vars = flow_variables
           # Flags that are set by this flow flow out of it
           (vars[:this_flow][:set_flags] +
-           # As do any flags set by its children which are marked as external
-           vars[:all][:set_flags_extern] +
-           # Other test methods are setting the flags
-           vars[:this_flow][:add_flags] +
-           # Other test methods are set in the children
-           vars[:all][:add_flags_extern] +
-           # And any flags which are set by a child and referenced in this flow
-           (vars[:this_flow][:referenced_flags] & vars[:sub_flows][:set_flags]) +
-           # And also intermediate flags, those are flags which are set by a child and referenced
-           # by a parent of the current flow
-           intermediate_variables).uniq.sort do |x, y|
+          # As do any flags set by its children which are marked as external
+          vars[:all][:set_flags_extern] +
+          # Other test methods are setting the flags
+          vars[:this_flow][:add_flags] +
+          # Other test methods are set in the children
+          vars[:all][:add_flags_extern] +
+          # And any flags which are set by a child and referenced in this flow
+          (vars[:this_flow][:referenced_flags] & vars[:sub_flows][:set_flags]) +
+          # And also intermediate flags, those are flags which are set by a child and referenced
+          # by a parent of the current flow
+          intermediate_variables).uniq.sort do |x, y|
             x = x[0] if x.is_a?(Array)
             y = y[0] if y.is_a?(Array)
             x <=> y

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/flow.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/flow.rb
@@ -229,17 +229,17 @@ module OrigenTesters
           vars = flow_variables
           # Flags that are set by this flow flow out of it
           (vars[:this_flow][:set_flags] +
-          # As do any flags set by its children which are marked as external
-          vars[:all][:set_flags_extern] +
-          # Other test methods are setting the flags
-          vars[:this_flow][:add_flags] +
-          # Other test methods are set in the children
-          vars[:all][:add_flags_extern] +
-          # And any flags which are set by a child and referenced in this flow
-          (vars[:this_flow][:referenced_flags] & vars[:sub_flows][:set_flags]) +
-          # And also intermediate flags, those are flags which are set by a child and referenced
-          # by a parent of the current flow
-          intermediate_variables).uniq.sort do |x, y|
+           # As do any flags set by its children which are marked as external
+           vars[:all][:set_flags_extern] +
+           # Other test methods are setting the flags
+           vars[:this_flow][:add_flags] +
+           # Other test methods are set in the children
+           vars[:all][:add_flags_extern] +
+           # And any flags which are set by a child and referenced in this flow
+           (vars[:this_flow][:referenced_flags] & vars[:sub_flows][:set_flags]) +
+           # And also intermediate flags, those are flags which are set by a child and referenced
+           # by a parent of the current flow
+           intermediate_variables).uniq.sort do |x, y|
             x = x[0] if x.is_a?(Array)
             y = y[0] if y.is_a?(Array)
             x <=> y

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/generator.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/generator.rb
@@ -42,6 +42,10 @@ module OrigenTesters
         def limits_workbook
           @@limits_workbook ||= LimitsWorkbook.new(manually_register: true)
         end
+
+        def shmoo_tests
+          flow.shmoo_tests
+        end
       end
     end
   end

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/shmoo_test.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/shmoo_test.rb
@@ -72,9 +72,11 @@ module OrigenTesters
           if axis = attrs.delete(:axis)
             axis = [axis] unless axis.is_a?(Array)
             axis.each_with_index do |a, i|
-              name = a.delete(:name) || "axis#{i + 1}"  # uniquify
-
-              axes << ShmooTestAxis.new(name, a)
+              aname = a.delete(:name) || "axis#{i + 1}"
+              if axes_names.include?(aname.to_sym)
+                fail "Axis name #{aname} is already used in shmoo test '#{@name}'"
+              end
+              axes << ShmooTestAxis.new(aname.to_sym, a)
             end
           else
             fail 'ShmooTest must have at least one axis'
@@ -109,6 +111,10 @@ module OrigenTesters
 
         def axes
           @axes ||= []
+        end
+
+        def axes_names
+          axes.map(&:name)
         end
 
         def lines
@@ -240,8 +246,11 @@ module OrigenTesters
           if tracking = attrs.delete(:tracking)
             tracking = [tracking] unless tracking.is_a?(Array)
             tracking.each_with_index do |t, i|
-              name = t.delete(:name) || "tracking#{i + 1}"  # uniquify
-              trackings << ShmooTestTracking.new(name, t)
+              tname = t.delete(:name) || "tracking#{i + 1}"
+              if trackings_names.include?(tname.to_sym)
+                fail "Tracking name #{tname} is already used in shmoo test axis '#{@name}'"
+              end
+              trackings << ShmooTestTracking.new(tname.to_sym, t)
             end
           end
 
@@ -306,6 +315,10 @@ module OrigenTesters
 
         def trackings
           @trackings ||= []
+        end
+
+        def trackings_names
+          trackings.map(&:name)
         end
       end
 

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/shmoo_test.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/shmoo_test.rb
@@ -1,0 +1,413 @@
+module OrigenTesters
+  module SmartestBasedTester
+    class V93K_SMT8
+      class ShmooTest
+        ATTRS =
+          %w(
+            name
+
+            bypass
+            target
+            result_title
+            result_type
+            result_signal
+            execution_order
+            ffc_error_count
+            axis
+          )
+
+        ALIASES = {
+          targets: :target,
+          title:   :result_title,
+          type:    :result_type,
+          signal:  :result_signal
+        }
+
+        DEFAULTS = {
+        }
+
+        NO_STRING_TYPES = [:list_strings, :list_classes, :class]
+        # Generate accessors for all attributes and their aliases
+        ATTRS.each do |attr|
+          if attr == 'name'
+            attr_reader attr.to_sym
+          else
+            attr_accessor attr.to_sym
+          end
+        end
+
+        # Define the aliases
+        ALIASES.each do |_alias, val|
+          define_method("#{_alias}=") do |v|
+            send("#{val}=", v)
+          end
+          define_method("#{_alias}") do
+            send(val)
+          end
+        end
+        attr_accessor :meta
+
+        def initialize(name, attrs = {})
+          @name = name
+          if interface.unique_test_names == :signature
+            if interface.flow.sig
+              @name = "#{name}_#{interface.flow.sig}"
+            end
+          elsif interface.unique_test_names == :flowname || interface.unique_test_names == :flow_name
+            @name = "#{name}_#{interface.flow.name.to_s.symbolize}"
+          elsif interface.unique_test_names == :preflowname || interface.unique_test_names == :pre_flow_name
+            @name = "#{interface.flow.name.to_s.symbolize}_#{name}"
+          elsif interface.unique_test_names
+            utn_string = interface.unique_test_names.to_s
+            if utn_string =~ /^prepend_/
+              utn_string = utn_string.gsub(/^prepend_/, '')
+              @name = "#{utn_string}_#{name}"
+            else
+              utn_string = utn_string.gsub(/^append_/, '')
+              @name = "#{name}_#{utn_string}"
+            end
+          end
+
+          # handle axis
+          if axis = attrs.delete(:axis)
+            axis = [axis] unless axis.is_a?(Array)
+            axis.each_with_index do |a, i|
+              name = a.delete(:name) || "axis#{i + 1}"  # uniquify
+
+              axes << ShmooTestAxis.new(name, a)
+            end
+          else
+            fail 'ShmooTest must have at least one axis'
+          end
+
+          # Set the defaults
+          self.class::DEFAULTS.each do |k, v|
+            send("#{k}=", v)
+          end
+          # Then the values that have been supplied
+          attrs.each do |k, v|
+            send("#{k}=", v) if respond_to?("#{k}=") && k.to_sym != :name
+          end
+        end
+
+        def smt8?
+          tester.smt8?
+        end
+
+        def inspect
+          "<ShmooTest: #{name}>"
+        end
+
+        # The name is immutable once the shmoo test is created, this will raise an error when called
+        def name=(val, options = {})
+          fail 'Once assigned the name of a shmoo test cannot be changed!'
+        end
+
+        def interface
+          Origen.interface
+        end
+
+        def axes
+          @axes ||= []
+        end
+
+        def lines
+          l = []
+          l << "shmoo #{name} {"
+          if target.length > 1
+            l << "    target = \#[#{target.map(&:to_s).join(',')}];"
+          else
+            l << "    target = #{target[0]};"
+          end
+          l << "    resultTitle = \"#{result_title}\";" if result_title
+          l << "    resultType = \"#{result_type}\";" if result_type
+          l << "    resultSignal = \"#{result_signal}\";" if result_signal
+          l << "    executionOrder = #{execution_order};" if execution_order
+          l << "    bypass = \"#{bypass}\";" if bypass
+          l << "    ffcErrorCount = #{ffc_error_count};" if ffc_error_count
+          l << ''
+
+          axes.each do |a|
+            a.lines.each do |al|
+              l << al
+            end
+          end
+
+          l << '}'
+          l
+        end
+      end
+
+      class ShmooTestAxis
+        ATTRS =
+          %w(
+            name
+
+            resource_type
+            resource_name
+            setup_signal
+
+            range_resolution
+            range_steps
+            range_fast_steps
+            range_scale
+            range_list
+            range_start
+            range_stop
+            range_relative_percentage_start
+            range_relative_percentage_stop
+            range_relative_value_start
+            range_relative_value_stop
+            tracking
+          )
+
+        ALIASES = {
+          resolution: :range_resolution,
+          steps:      :range_steps,
+          fast_steps: :range_fast_steps
+        }
+
+        # Generate accessors for all attributes and their aliases
+        ATTRS.each do |attr|
+          if attr == 'name'
+            attr_reader attr.to_sym
+          else
+            attr_accessor attr.to_sym
+          end
+        end
+
+        def initialize(name, attrs = {})
+          @name = name
+
+          @resource_type = attrs.delete(:resource_type)
+          @resource_name = attrs.delete(:resource_name)
+          @setup_signal = attrs.delete(:setup_signal)
+
+          if range_list = attrs.delete(:range_list)
+            @range_list = range_list
+          elsif attrs[:range] && attrs[:range].is_a?(Array)
+            @range_list = attrs.delete(:range)
+          else
+            if range = attrs.delete(:range)
+              if range.is_a?(Range)
+                @range_start = range.begin
+                @range_stop = range.end
+                @range_steps = attrs.delete(:range_steps) || attrs.delete(:steps)
+                @range_resolution = attrs.delete(:range_resolution) || attrs.delete(:resolution)
+                @range_fast_steps = attrs.delete(:range_fast_steps) || attrs.delete(:fast_steps)
+              elsif range.is_a?(Hash)
+                @range_start = range[:start]
+                @range_stop = range[:stop]
+                @range_steps = range[:steps]
+                @range_resolution = range[:resolution]
+                @range_fast_steps = range[:fast_steps]
+              end
+            elsif range_relative_percentage = attrs.delete(:range_relative_percentage)
+              if range_relative_percentage.is_a?(Range)
+                @range_relative_percentage_start = range_relative_percentage.begin
+                @range_relative_percentage_stop = range_relative_percentage.end
+                @range_steps = attrs.delete(:range_steps) || attrs.delete(:steps)
+                @range_resolution = attrs.delete(:range_resolution) || attrs.delete(:resolution)
+                @range_fast_steps = attrs.delete(:range_fast_steps) || attrs.delete(:fast_steps)
+              elsif range_relative_percentage.is_a?(Hash)
+                @range_relative_percentage_start = range_relative_percentage[:start]
+                @range_relative_percentage_stop = range_relative_percentage[:stop]
+                @range_steps = range_relative_percentage[:steps]
+                @range_resolution = range_relative_percentage[:resolution]
+                @range_fast_steps = range_relative_percentage[:fast_steps]
+              end
+            elsif range_relative_value = attrs.delete(:range_relative_value)
+              if range_relative_value.is_a?(Range)
+                @range_relative_value_start = range_relative_value.begin
+                @range_relative_value_stop = range_relative_value.end
+                @range_steps = attrs.delete(:range_steps) || attrs.delete(:steps)
+                @range_resolution = attrs.delete(:range_resolution) || attrs.delete(:resolution)
+                @range_fast_steps = attrs.delete(:range_fast_steps) || attrs.delete(:fast_steps)
+              elsif range_relative_value.is_a?(Hash)
+                @range_relative_value_start = range_relative_value[:start]
+                @range_relative_value_stop = range_relative_value[:stop]
+                @range_steps = range_relative_value[:steps]
+                @range_resolution = range_relative_value[:resolution]
+                @range_fast_steps = range_relative_value[:fast_steps]
+              end
+            else
+              attrs.each do |k, v|
+                send("#{k}=", v) if respond_to?("#{k}=") && k.to_sym != :name
+              end
+            end
+          end
+
+          if tracking = attrs.delete(:tracking)
+            tracking = [tracking] unless tracking.is_a?(Array)
+            tracking.each_with_index do |t, i|
+              name = t.delete(:name) || "tracking#{i + 1}"  # uniquify
+              trackings << ShmooTestTracking.new(name, t)
+            end
+          end
+
+          attrs.each do |k, v|
+            send("#{k}=", v) if respond_to?("#{k}=") && k.to_sym != :name
+          end
+        end
+
+        def lines
+          l = []
+          l << "    axis [#{name}] = {"
+          if resource_type
+            l << "        resourceType = #{resource_type};"
+          else
+            fail 'Shmoo Axis must have a resource type'
+          end
+          if resource_name
+            l << "        resourceName = \"#{resource_name}\";"
+          else
+            fail 'Shmoo Axis must have a resource name'
+          end
+          l << "        setup_signal = \"#{setup_signal}\";" if setup_signal
+          if range_list
+            l << "        range.list = \#[#{range_list.map(&:to_s).join(',')}];"
+          elsif range_start && range_stop
+            l << "        range.start = #{range_start};"
+            l << "        range.stop = #{range_stop};"
+          elsif range_relative_percentage_start && range_relative_percentage_stop
+            l << "        range.relativePercentage.start = #{range_relative_percentage_start};"
+            l << "        range.relativePercentage.stop = #{range_relative_percentage_stop};"
+          elsif range_relative_value_start && range_relative_value_stop
+            l << "        range.relativeValue.start = #{range_relative_value_start};"
+            l << "        range.relativeValue.stop = #{range_relative_value_stop};"
+          else
+            fail 'Shmoo Axis must have a range (start & stop) or range list'
+          end
+          if range_resolution && range_steps.nil?
+            l << "        range.resolution = #{range_resolution};"
+            if range_fast_steps
+              fail 'Shmoo Axis cannot have range fast steps with range resolution'
+            end
+          elsif range_steps && range_resolution.nil?
+            l << "        range.steps = #{range_steps};"
+            if range_fast_steps
+              l << "        range.fastSteps = #{range_fast_steps};"
+            end
+          elsif range_resolution.nil? && range_steps.nil?
+            fail 'Shmoo Axis must define either range resolution or range steps'
+          else
+            fail 'Shmoo Axis must define either range resolution or range steps, but not both'
+          end
+          l << '' if trackings.length > 0
+          trackings.each do |t|
+            t.lines.each do |tl|
+              l << tl
+            end
+          end
+
+          l << '    };'
+          l
+        end
+
+        def trackings
+          @trackings ||= []
+        end
+      end
+
+      class ShmooTestTracking
+        ATTRS =
+          %w(
+            name
+
+            resource_type
+            resource_name
+            setup_signal
+
+            range_list
+            range_start
+            range_stop
+            range_relative_percentage_start
+            range_relative_percentage_stop
+            range_relative_value_start
+            range_relative_value_stop
+          )
+
+        # Generate accessors for all attributes and their aliases
+        ATTRS.each do |attr|
+          if attr == 'name'
+            attr_reader attr.to_sym
+          else
+            attr_accessor attr.to_sym
+          end
+        end
+
+        def initialize(name, attrs = {})
+          @name = name
+
+          @resource_type = attrs.delete(:resource_type)
+          @resource_name = attrs.delete(:resource_name)
+          @setup_signal = attrs.delete(:setup_signal)
+
+          if range = attrs.delete(:range)
+            if range.is_a?(Range)
+              @range_start = range.begin
+              @range_stop = range.end
+            elsif range.is_a?(Hash)
+              @range_start = range[:start]
+              @range_stop = range[:stop]
+            elsif range.is_a?(Array)
+              @range_list = range
+            end
+          elsif range_relative_percentage = attrs.delete(:range_relative_percentage)
+            if range_relative_percentage.is_a?(Range)
+              @range_relative_percentage_start = range_relative_percentage.begin
+              @range_relative_percentage_stop = range_relative_percentage.end
+            elsif range_relative_percentage.is_a?(Hash)
+              @range_relative_percentage_start = range_relative_percentage[:start]
+              @range_relative_percentage_stop = range_relative_percentage[:stop]
+            end
+          elsif range_relative_value = attrs.delete(:range_relative_value)
+            if range_relative_value.is_a?(Range)
+              @range_relative_value_start = range_relative_value.begin
+              @range_relative_value_stop = range_relative_value.end
+            elsif range_relative_value.is_a?(Hash)
+              @range_relative_value_start = range_relative_value[:start]
+              @range_relative_value_stop = range_relative_value[:stop]
+            end
+          else
+            attrs.each do |k, v|
+              send("#{k}=", v) if respond_to?("#{k}=") && k.to_sym != :name
+            end
+          end
+        end
+
+        def lines
+          l = []
+          l << "        tracking [#{name}] = {"
+          if resource_type
+            l << "            resourceType = #{resource_type};"
+          else
+            fail 'Shmoo Tracking must have a resource type'
+          end
+          if resource_name
+            l << "            resourceName = \"#{resource_name}\";"
+          else
+            fail 'Shmoo Tracking must have a resource name'
+          end
+          l << "            setup_signal = \"#{setup_signal}\";" if setup_signal
+          if range_list
+            l << "            range.list = \#[#{range_list.map(&:to_s).join(',')}];"
+          elsif range_start && range_stop
+            l << "            range.start = #{range_start};"
+            l << "            range.stop = #{range_stop};"
+          elsif range_relative_percentage_start && range_relative_percentage_stop
+            l << "            range.relativePercentage.start = #{range_relative_percentage_start};"
+            l << "            range.relativePercentage.stop = #{range_relative_percentage_stop};"
+          elsif range_relative_value_start && range_relative_value_stop
+            l << "            range.relativeValue.start = #{range_relative_value_start};"
+            l << "            range.relativeValue.stop = #{range_relative_value_stop};"
+          else
+            fail 'Shmoo Tracking must have a range (start & stop) or range list'
+          end
+          l << '        };'
+          l
+        end
+      end
+    end
+  end
+end

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/shmoo_tests.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/shmoo_tests.rb
@@ -1,0 +1,66 @@
+module OrigenTesters
+  module SmartestBasedTester
+    class Base
+      class ShmooTests
+        # Origen::Tester::Generator not included since test suites do not have their
+        # own top-level sheet, they will be incorporated within the flow sheet
+
+        attr_accessor :flow, :collection
+
+        def initialize(flow)
+          @flow = flow
+          @collection = []
+          @existing_names = {}
+          # Test names also have to be unique vs. the current flow name
+          if tester.smt8?
+            @existing_names[flow.filename.sub('.flow', '').to_s] = true
+          end
+        end
+
+        def filename
+          flow.filename
+        end
+
+        def add(name, options = {})
+          symbol = name.is_a?(Symbol)
+          name = make_unique(name)
+          # Ensure names given as a symbol stay as a symbol, this is more for
+          # alignment to existing test cases than anything else
+          name = name.to_sym if symbol
+          shmoo = platform::ShmooTest.new(name, options)
+          @collection << shmoo
+          shmoo
+        end
+        alias_method :run, :add
+        alias_method :run_and_branch, :add
+
+        def platform
+          Origen.interface.platform
+        end
+
+        def finalize
+          # collection.each do |suite|
+          # end
+        end
+
+        def sorted_collection
+          @collection.sort_by { |st| st.name.to_s }
+        end
+
+        private
+
+        def make_unique(name)
+          name = name.to_s
+          tempname = name
+          i = 0
+          while @existing_names[tempname]
+            i += 1
+            tempname = "#{name}_#{i}"
+          end
+          @existing_names[tempname] = true
+          tempname
+        end
+      end
+    end
+  end
+end

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/shmoo_tests.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/shmoo_tests.rb
@@ -39,8 +39,34 @@ module OrigenTesters
         end
 
         def finalize
-          # collection.each do |suite|
-          # end
+          # match any formatting difference between test suite shmoo and test flow shmoo
+          @collection.each do |shmoo_test|
+            shmoo_test.targets.each_with_index do |target, i|
+              target_is_a_test_suite = false
+              flow.test_suites.sorted_collection.each do |suite|
+                if suite.name.to_s == target.to_s
+                  target_is_a_test_suite = true
+                  break
+                end
+              end
+
+              unless target_is_a_test_suite
+                target_is_a_test_flow = false
+                flow.sub_flows.each do |name, path|
+                  target_name = target.to_s.gsub(' ', '_')
+                  if name.to_s.downcase == target_name.to_s.downcase
+                    target_is_a_test_flow = true
+                    shmoo_test.targets[i] = name
+                    break
+                  end
+                end
+
+                unless target_is_a_test_flow
+                  fail "Shmoo test target '#{target}' for shmoo test '#{shmoo_test.name}' not found in test suites or sub_flows"
+                end
+              end
+            end
+          end
         end
 
         def sorted_collection

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/templates/template.flow.erb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/templates/template.flow.erb
@@ -22,6 +22,12 @@ flow <%= flow_name %> {
 %   end
 
 % end
+% shmoo_tests.sorted_collection.each do |shmoo_test|
+%   shmoo_test.lines.each do |line|
+        <%= line %>
+%   end
+
+% end
 % auxiliary_flows.each do |name, path|
         flow <%= name %> calls <%= path %> {}
 % end

--- a/lib/origen_testers/test/interface.rb
+++ b/lib/origen_testers/test/interface.rb
@@ -398,6 +398,14 @@ module OrigenTesters
         end
       end
 
+      def shmoo(name, targets, options = {})
+        if tester.v93k? && tester.smt8?
+          targets = [targets] unless targets.is_a?(Array)
+          st = shmoo_tests.run(name, { targets: targets }.merge(options))
+          flow.test st, options
+        end
+      end
+
       def por(options = {})
         options = {
           instance_not_available: true

--- a/program/components/_prb1_main.rb
+++ b/program/components/_prb1_main.rb
@@ -263,7 +263,7 @@ Flow.create do |options|
     log 'shmoo test insertion works as expected, shmoo over test suite 1D'
     range = { start: 3.0, stop: 5.0, steps: 10 }
     axis = { name: :axis1, resource_type: 'specVariable', resource_name: 'vcc', range: range }
-    shmoo :shmoo_over_ts_1D, :test200_1, title: 'shmooOverTest', execution_order: :horizontal, axis: axis
+    shmoo :shmoo_over_ts_1D, :cc_test_0, title: 'shmooOverTest', execution_order: :horizontal, axis: axis
 
     log 'shmoo test insertion works as expected, shmoo over test suite 3D'
     axis = [
@@ -271,15 +271,15 @@ Flow.create do |options|
       { resource_type: :specVariable, resource_name: 'vcc', range: 3..5, steps: 10 },
       { resource_type: :suiteParameter, resource_name: 'forceVoltage', range: 4.8..5.2, steps: 10 }
     ]
-    shmoo :shmoo_over_ts_3D, :test200_2, axis: axis, if_failed: :g200 
+    shmoo :shmoo_over_ts_3D, :erase_all, axis: axis, if_enable: 'do_erase'
 
     log 'shmoo test insertion works as expected, shmoo over multiple test suites'
     axis = { name: :vih, resource_type: :instrumentProperty, resource_name: 'vih', range_relative_percentage: -0.01..0.01, steps: 10 }
-    shmoo :shmoo_over_ts_multiple_ts, [:test200_1, :test200_2], title: 'shmooOverMultiTS', axis: axis 
+    shmoo :shmoo_over_ts_multiple_ts, [:margin_read0_ckbd, :margin_read1_ckbd], title: 'shmooOverMultiTS', axis: axis 
 
     log 'shmoo test insertion works as expected, shmoo over test flow'
     axis = { name: :vcc, resource_type: :specVariable, resource_name: 'vcc', range: 3..5, steps: 10 }
-    shmoo :shmoo_over_tf, :erase, title: 'shmooOverTF', axis: axis, if_enable: 'do_erase'
+    shmoo :shmoo_over_tf, "200Mhz Tests", title: 'shmooOverTF', axis: axis, if_failed: :g200
 
     log 'shmoo test insertion works as expected, shmoo with tracking parameters'
     range = { start: 0.5, stop: 3.5, steps: 10 }

--- a/program/components/_prb1_main.rb
+++ b/program/components/_prb1_main.rb
@@ -259,4 +259,33 @@ Flow.create do |options|
 
   double_int_type_check :type_check, number: 6035
 
+  if tester.smt8?
+    log 'shmoo test insertion works as expected, shmoo over test suite 1D'
+    range = { start: 3.0, stop: 5.0, steps: 10 }
+    axis = { name: :axis1, resource_type: 'specVariable', resource_name: 'vcc', range: range }
+    shmoo :shmoo_over_ts_1D, :test200_1, { title: 'shmooOverTest', execution_order: :horizontal, axis: axis }
+
+    log 'shmoo test insertion works as expected, shmoo over test suite 3D'
+    axis = [
+      { resource_type: :instrumentProperty, resource_name: 'vih', range_relative_percentage: -0.01..0.01, steps: 10 },
+      { resource_type: :specVariable, resource_name: 'vcc', range: 3..5, steps: 10 },
+      { resource_type: :suiteParameter, resource_name: 'forceVoltage', range: 4.8..5.2, steps: 10 }
+    ]
+    shmoo :shmoo_over_ts_3D, :test200_2, axis: axis
+
+    log 'shmoo test insertion works as expected, shmoo over multiple test suites'
+    axis = { name: :vih, resource_type: :instrumentProperty, resource_name: 'vih', range_relative_percentage: -0.01..0.01, steps: 10 }
+    shmoo :shmoo_over_ts_multiple_ts, [:test200_1, :test200_2], { title: 'shmooOverMultiTS', axis: axis }
+
+    log 'shmoo test insertion works as expected, shmoo over test flow'
+    axis = { name: :vcc, resource_type: :specVariable, resource_name: 'vcc', range: 3..5, steps: 10 }
+    shmoo :shmoo_over_tf, :erase, { title: 'shmooOverTF', axis: axis }
+
+    log 'shmoo test insertion works as expected, shmoo with tracking parameters'
+    range = { start: 0.5, stop: 3.5, steps: 10 }
+    tracking = { name: :voh, resource_type: 'instrumentProperty', resource_name: 'voh', range_relative_value: 1..2 }
+    axis = { name: :vcc, resource_type: 'specVariable', resource_name: 'vcc', range: range, tracking: tracking }
+    shmoo :shmoo_with_tracking_para, :erase, { title: 'shmooOverTF', axis: axis }
+  end
+
 end

--- a/program/components/_prb1_main.rb
+++ b/program/components/_prb1_main.rb
@@ -263,7 +263,7 @@ Flow.create do |options|
     log 'shmoo test insertion works as expected, shmoo over test suite 1D'
     range = { start: 3.0, stop: 5.0, steps: 10 }
     axis = { name: :axis1, resource_type: 'specVariable', resource_name: 'vcc', range: range }
-    shmoo :shmoo_over_ts_1D, :test200_1, { title: 'shmooOverTest', execution_order: :horizontal, axis: axis }
+    shmoo :shmoo_over_ts_1D, :test200_1, title: 'shmooOverTest', execution_order: :horizontal, axis: axis
 
     log 'shmoo test insertion works as expected, shmoo over test suite 3D'
     axis = [
@@ -271,21 +271,21 @@ Flow.create do |options|
       { resource_type: :specVariable, resource_name: 'vcc', range: 3..5, steps: 10 },
       { resource_type: :suiteParameter, resource_name: 'forceVoltage', range: 4.8..5.2, steps: 10 }
     ]
-    shmoo :shmoo_over_ts_3D, :test200_2, axis: axis
+    shmoo :shmoo_over_ts_3D, :test200_2, axis: axis, if_failed: :g200 
 
     log 'shmoo test insertion works as expected, shmoo over multiple test suites'
     axis = { name: :vih, resource_type: :instrumentProperty, resource_name: 'vih', range_relative_percentage: -0.01..0.01, steps: 10 }
-    shmoo :shmoo_over_ts_multiple_ts, [:test200_1, :test200_2], { title: 'shmooOverMultiTS', axis: axis }
+    shmoo :shmoo_over_ts_multiple_ts, [:test200_1, :test200_2], title: 'shmooOverMultiTS', axis: axis 
 
     log 'shmoo test insertion works as expected, shmoo over test flow'
     axis = { name: :vcc, resource_type: :specVariable, resource_name: 'vcc', range: 3..5, steps: 10 }
-    shmoo :shmoo_over_tf, :erase, { title: 'shmooOverTF', axis: axis }
+    shmoo :shmoo_over_tf, :erase, title: 'shmooOverTF', axis: axis, if_enable: 'do_erase'
 
     log 'shmoo test insertion works as expected, shmoo with tracking parameters'
     range = { start: 0.5, stop: 3.5, steps: 10 }
     tracking = { name: :voh, resource_type: 'instrumentProperty', resource_name: 'voh', range_relative_value: 1..2 }
     axis = { name: :vcc, resource_type: 'specVariable', resource_name: 'vcc', range: range, tracking: tracking }
-    shmoo :shmoo_with_tracking_para, :erase, { title: 'shmooOverTF', axis: axis }
+    shmoo :shmoo_with_tracking_para, :erase, title: 'shmooOverTF', axis: axis
   end
 
 end

--- a/templates/origen_guides/program/v93ksmt8.md.erb
+++ b/templates/origen_guides/program/v93ksmt8.md.erb
@@ -134,4 +134,69 @@ If you wish to have a collapse-able block for the variables, you need to set the
 flow_variable_grouping: true
 ~~~
 
+#### Built-In Shmoo Element
+
+SMT8 provides a built in shmoo element that can be used to shmoo a test suite or test flow.
+In order to add setup and execute code to the flow, create the shmoo_test object using `shmoo_tests.run(name, options)` and add it to the flow with `flow.test` method.
+
+
+Example of integrating the shmoo api in an interface:
+
+~~~ruby
+def shmoo(name, targets, options = {})
+  if tester.v93k? && tester.smt8?
+    targets = [targets] unless targets.is_a?(Array)
+    st = shmoo_tests.run(name, { targets: targets }.merge(options))
+    flow.test st, options
+  end
+end
+~~~
+
+
+Then in the flow, you can add the shmoo element to the flow with the following code:
+
+~~~ruby
+Flow.create
+  ...
+  range = { start: 3.0, stop: 5.0, steps: 10 }
+  axis = { name: :axis1, resource_type: 'specVariable', resource_name: 'vcc', range: range }
+  shmoo :shmoo_over_ts_1D, :cc_test_0, title: 'shmooOverTest', execution_order: :horizontal, axis: axis
+  ...
+end
+~~~
+
+Please see Advantest TDC Topic 253309 for details ahbout Shmoo parameters.
+
+
+The above code will generate the following flow code:
+
+~~~java
+flow <FLOW> {
+    setup {
+        ...
+        shmoo shmoo_over_ts_1D {
+            target = cc_test_0;
+            resultTitle = "shmooOverTest";
+            executionOrder = horizontal;
+		
+            axis [axis1] = {
+                resourceType = specVariable;
+                resourceName = "vcc";
+                range.start = 3.0;
+                range.stop = 5.0;
+                range.steps = 10;
+            };
+        }
+        ...
+    }
+
+    execute {
+        ...
+        shmoo_over_ts_1D.execute();
+        ...
+    }
+}
+~~~
+
+
 % end


### PR DESCRIPTION
Implements native shmoo testflow element in SMT8 as describe in TDC Topic 253309.

**Example interface:**
```
def shmoo(name, targets, options = {})
  if tester.v93k? && tester.smt8?
    targets = [targets] unless targets.is_a?(Array)
    st = shmoo_tests.run(name, { targets: targets }.merge(options))
    flow.test st, options
  end
end
```

**Example flow:**
```
Flow.create
  ...
  test :cc_test_0, options
  ...
  range = { start: 3.0, stop: 5.0, steps: 10 }
  axis = { name: :axis1, resource_type: 'specVariable', resource_name: 'vcc', range: range }
  shmoo :shmoo_over_ts_1D, :cc_test_0, title: 'shmooOverTest', execution_order: :horizontal, axis: axis
  ...
end
```

**Renders:**	  
```
flow <FLOW> {
    setup {
        shmoo shmoo_over_ts_1D {
            target = cc_test_0;
            resultTitle = "shmooOverTest";
            executionOrder = horizontal;
		
            axis [axis1] = {
                resourceType = specVariable;
                resourceName = "vcc";
                range.start = 3.0;
                range.stop = 5.0;
                range.steps = 10;
            };
        }
    }

    execute {
        ...
        cc_test.execute();
        ...
        shmoo_over_ts_1D.execute();
        ...
    }
}
```