### PR TITLE
Feature/smt8 ods advantest prefer way

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base/limits_file.rb
+++ b/lib/origen_testers/smartest_based_tester/base/limits_file.rb
@@ -129,7 +129,9 @@ module OrigenTesters
               end
               if sbin = set_result.find(:softbin)
                 o[:bin_s_num] = sbin.to_a[0] || o[:bin_s_num]
-                o[:bin_s_name] = bin_names[:soft][sbin.to_a[0]][:name]
+                if o[:bin_s_name].nil?
+                  o[:bin_s_name] = bin_names[:soft][sbin.to_a[0]][:name]
+                end
               end
             end
             delayed = on_fail.find(:delayed)

--- a/lib/origen_testers/smartest_based_tester/v93k_smt8/limits_workbook.rb
+++ b/lib/origen_testers/smartest_based_tester/v93k_smt8/limits_workbook.rb
@@ -115,16 +115,16 @@ module OrigenTesters
         def add_bin_sheets(spreadsheet)
           table = spreadsheet.table 'Software_Bins'
           row = table.row
-          row.cell 'Software Bin'
           row.cell 'Software Bin Name'
+          row.cell 'Software Bin'
           row.cell 'Hardware Bin'
           row.cell 'Result'
           row.cell 'Color'
           row.cell 'Priority'
           @softbins.each do |sbin, attrs|
             row = table.row
-            row.cell sbin
             row.cell attrs[:name]
+            row.cell sbin
             row.cell attrs[:bin]
             row.cell attrs[:result]
             row.cell attrs[:color]
@@ -134,13 +134,13 @@ module OrigenTesters
           # Write out the bin table
           table = spreadsheet.table 'Hardware_Bins'
           row = table.row
-          row.cell 'Hardware Bin'
           row.cell 'Hardware Bin Name'
+          row.cell 'Hardware Bin'
           row.cell 'Result'
           @bins.each do |bin, attrs|
             row = table.row
-            row.cell bin
             row.cell attrs[:name]
+            row.cell bin
             row.cell attrs[:result]
           end
         end


### PR DESCRIPTION
Currently software bin description is using test suite name.  Allow Software Bin description to be passing from app.

Switch the column orders 
Software Bin Description and Software bin - Software Bin Description is the column before Software bin
Hardware Bin Description and Hardware bin - Hardware Bin Description is the column before Hardware bin

This only impacts the .ods file