### PR TITLE
eof charz generation has a valid usecase for referencing the stored instance - stop the spam

### DIFF
--- a/lib/origen_testers/charz.rb
+++ b/lib/origen_testers/charz.rb
@@ -42,8 +42,8 @@ module OrigenTesters
     # the instance to be used is no longer set, so instead of referencing the session, use the one that we've
     # stored already
     def charz_instance
-      unless charz_session.current_instance.nil?
-        set_charz_instance(charz_session.current_instance)
+      unless charz_session.current_instance(stored_instance_valid: true).nil?
+        set_charz_instance(charz_session.current_instance(stored_instance_valid: true))
       end
       @charz_instance
     end

--- a/lib/origen_testers/charz/session.rb
+++ b/lib/origen_testers/charz/session.rb
@@ -73,10 +73,12 @@ module OrigenTesters
         end
       end
 
-      def current_instance
+      def current_instance(options = {})
         instance = @current_instance || instances.first
         if instance.nil? && @stored_instance
-          Origen.log.deprecate '@current_instance had to source @stored_instance. This likely means charz_session.<some_attr> is being queried when the newer charz_instance.<some_attr> should be instead'
+          unless options[:stored_instance_valid]
+            Origen.log.deprecate '@current_instance had to source @stored_instance. This likely means charz_session.<some_attr> is being queried when the newer charz_instance.<some_attr> should be instead'
+          end
           instance = @stored_instance
         end
         instance


### PR DESCRIPTION
Minor changes to prevent spamming the console with deprecation warnings when using end of flow charz generation placement, which has a valid use case for using the stored instance. Even outside eof, referencing charz_session.<attr> via charz_instance.<attr> is always valid.