### PR TITLE
Skip typecast for V93K parameter when default value is empty string

### DIFF
--- a/approved/v93k/testflow/mfh.testflow.group/custom_tests.tf
+++ b/approved/v93k/testflow/mfh.testflow.group/custom_tests.tf
@@ -48,12 +48,22 @@ tm_6:
   "testName" = "Functional";
   "testerState" = "CONNECTED";
 tm_7:
+  "booleanArg" = "1";
+  "booleanNoDefault" = "";
+  "currentArg" = "1[A]";
+  "currentNoDefault" = "";
   "doubleArg" = "5.22";
-  "doubleArgNodef" = "";
+  "doubleNoDefault" = "";
+  "frequencyArg" = "1000000[Hz]";
+  "frequencyNoDefault" = "";
   "integerArg" = "5";
-  "integerArgNodef" = "";
+  "integerNoDefault" = "";
   "testName" = "Functional";
   "testerState" = "CONNECTED";
+  "timeArg" = "10[s]";
+  "timeNoDefault" = "";
+  "voltageArg" = "1.2[V]";
+  "voltageNoDefault" = "";
 
 end
 -----------------------------------------------------------------

--- a/approved/v93k/testflow/mfh.testflow.group/custom_tests.tf
+++ b/approved/v93k/testflow/mfh.testflow.group/custom_tests.tf
@@ -47,6 +47,13 @@ tm_6:
   "myArg2" = "VOLT";
   "testName" = "Functional";
   "testerState" = "CONNECTED";
+tm_7:
+  "doubleArg" = "5.22";
+  "doubleArgNodef" = "";
+  "integerArg" = "5";
+  "integerArgNodef" = "";
+  "testName" = "Functional";
+  "testerState" = "CONNECTED";
 
 end
 -----------------------------------------------------------------
@@ -61,6 +68,8 @@ tm_3:
 tm_5:
   "Functional" = "":"NA":"":"NA":"":"":"";
 tm_6:
+  "Functional" = "":"NA":"":"NA":"":"":"";
+tm_7:
   "Functional" = "":"NA":"":"NA":"":"":"";
 
 end
@@ -79,6 +88,8 @@ tm_5:
   testmethod_class = "MyTml.TestC";
 tm_6:
   testmethod_class = "MyTml.TestC";
+tm_7:
+  testmethod_class = "MyTml.TestD";
 
 end
 -----------------------------------------------------------------

--- a/lib/origen_testers/smartest_based_tester/base/test_method.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_method.rb
@@ -121,6 +121,7 @@ module OrigenTesters
         end
 
         def handle_val_type(val, type, attr)
+          return val if val == ''
           case type
           when :current, 'CURR'
             "#{val}[A]"

--- a/lib/origen_testers/smartest_based_tester/base/test_method.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_method.rb
@@ -2,7 +2,7 @@ module OrigenTesters
   module SmartestBasedTester
     class Base
       class TestMethod
-        FORMAT_TYPES = [:current, :voltage, :time, :string, :integer, :double, :boolean, :class, :list_strings, :list_classes]
+        FORMAT_TYPES = [:current, :voltage, :time, :frequency, :string, :integer, :double, :boolean, :class, :list_strings, :list_classes]
 
         # Returns the object representing the test method library that the
         # given test method is defined in

--- a/lib/origen_testers/test/custom_test_interface.rb
+++ b/lib/origen_testers/test/custom_test_interface.rb
@@ -47,6 +47,13 @@ module OrigenTesters
         end
       end
 
+      def custom_d(name, options = {})
+        name = "custom_d_#{name}".to_sym
+        if tester.v93k?
+          ti = test_methods.my_tml.test_d
+        end
+      end
+
       def custom_hash(name, options = {})
         name = "custom_hash_#{name}".to_sym
         if tester.v93k? && tester.smt8?
@@ -128,6 +135,14 @@ module OrigenTesters
                       end
                     end
                   }
+                },
+                test_d:    {
+                  tester_state:      [:string, 'CONNECTED', %w(CONNECTED UNCHANGED)],
+                  test_name:         [:string, 'Functional'],
+                  integer_arg:       [:integer, 5.22],
+                  integer_arg_nodef: [:integer, ''],
+                  double_arg:        [:double, '5.22'],
+                  double_arg_nodef:  [:double, '']
                 },
                 test_hash: {
                   # Parameters can be defined with an underscored symbol as the name, this can be used

--- a/lib/origen_testers/test/custom_test_interface.rb
+++ b/lib/origen_testers/test/custom_test_interface.rb
@@ -137,12 +137,22 @@ module OrigenTesters
                   }
                 },
                 test_d:    {
-                  tester_state:      [:string, 'CONNECTED', %w(CONNECTED UNCHANGED)],
-                  test_name:         [:string, 'Functional'],
-                  integer_arg:       [:integer, 5.22],
-                  integer_arg_nodef: [:integer, ''],
-                  double_arg:        [:double, '5.22'],
-                  double_arg_nodef:  [:double, '']
+                  tester_state:         [:string, 'CONNECTED', %w(CONNECTED UNCHANGED)],
+                  test_name:            [:string, 'Functional'],
+                  current_arg:          [:current, 1],
+                  current_no_default:   [:current, ''],
+                  voltage_arg:          [:voltage, 1.2],
+                  voltage_no_default:   [:voltage, ''],
+                  time_arg:             [:time, 10],
+                  time_no_default:      [:time, ''],
+                  frequency_arg:        [:frequency, 1_000_000],
+                  frequency_no_default: [:frequency, ''],
+                  integer_arg:          [:integer, 5.22],
+                  integer_no_default:   [:integer, ''],
+                  double_arg:           [:double, '5.22'],
+                  double_no_default:    [:double, ''],
+                  boolean_arg:          [:boolean, true],
+                  boolean_no_default:   [:boolean, '']
                 },
                 test_hash: {
                   # Parameters can be defined with an underscored symbol as the name, this can be used

--- a/program/custom_tests.rb
+++ b/program/custom_tests.rb
@@ -15,5 +15,8 @@ Flow.create interface: 'OrigenTesters::Test::CustomTestInterface', flow_descript
 
     custom_c :test6, number: 30060
     custom_c :test7, number: 30070, my_arg1: 'KEEP_ME'
+
+    custom_d :test8, number: 30080
   end
 end
+


### PR DESCRIPTION
Prevent empty default value from being converted to default type value.  Ex. `''.to_i => 0`
