### PR TITLE
Patch for rendering empty default TM parameters on SMT8

### DIFF
--- a/approved/v93k/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k/testflow/mfh.testflow.group/prb1.tf
@@ -14,7 +14,9 @@ tm_100:
   "testName" = "Functional";
 tm_101:
   "double" = "1.0";
+  "doubleNoDefault" = "";
   "int" = "1";
+  "intNoDefault" = "";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";

--- a/approved/v93k_disable_flow/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_disable_flow/testflow/mfh.testflow.group/prb1.tf
@@ -14,7 +14,9 @@ tm_100:
   "testName" = "Functional";
 tm_101:
   "double" = "1.0";
+  "doubleNoDefault" = "";
   "int" = "1";
+  "intNoDefault" = "";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";

--- a/approved/v93k_enable_flow/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_enable_flow/testflow/mfh.testflow.group/prb1.tf
@@ -14,7 +14,9 @@ tm_100:
   "testName" = "Functional";
 tm_101:
   "double" = "1.0";
+  "doubleNoDefault" = "";
   "int" = "1";
+  "intNoDefault" = "";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";

--- a/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -563,7 +563,9 @@ flow PRB1_MAIN {
 
         suite type_check calls myTypeCheck.MyHashExampleClass {
             double = 1.0;
+            doubleNoDefault = 0.0;
             int = 1;
+            intNoDefault = 0;
         }
 
         suite xcvr_fs_vilvih calls ac_tml.AcTest.FunctionalTest {

--- a/approved/v93k_global/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_global/testflow/mfh.testflow.group/prb1.tf
@@ -14,7 +14,9 @@ tm_100:
   "testName" = "Functional";
 tm_101:
   "double" = "1.0";
+  "doubleNoDefault" = "";
   "int" = "1";
+  "intNoDefault" = "";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";

--- a/approved/v93k_multiport/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_multiport/testflow/mfh.testflow.group/prb1.tf
@@ -14,7 +14,9 @@ tm_100:
   "testName" = "Functional";
 tm_101:
   "double" = "1.0";
+  "doubleNoDefault" = "";
   "int" = "1";
+  "intNoDefault" = "";
 tm_102:
   "forceMode" = "VOLT";
   "forceValue" = "3.8[V]";

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/PRB1_MAIN.flow
@@ -563,7 +563,9 @@ flow PRB1_MAIN {
 
         suite type_check calls myTypeCheck.MyHashExampleClass {
             double = 1.0;
+            doubleNoDefault = 0.0;
             int = 1;
+            intNoDefault = 0;
         }
 
         suite xcvr_fs_vilvih calls ac_tml.AcTest.FunctionalTest {

--- a/lib/origen_testers/smartest_based_tester/base/test_method.rb
+++ b/lib/origen_testers/smartest_based_tester/base/test_method.rb
@@ -121,7 +121,7 @@ module OrigenTesters
         end
 
         def handle_val_type(val, type, attr)
-          return val if val == ''
+          return val if val == '' && !tester.smt8?
           case type
           when :current, 'CURR'
             "#{val}[A]"

--- a/lib/origen_testers/test/interface.rb
+++ b/lib/origen_testers/test/interface.rb
@@ -86,8 +86,10 @@ module OrigenTesters
                 my_type_check_test: {
                   # [OPTIONAL] The C++ test method class name can be overridden from the default like this:
                   class_name: 'MyHashExampleClass',
-                  int:        [:integer, 1],
-                  double:     [:double,  1.0]
+                  int:               [:integer, 1],
+                  double:            [:double,  1.0],
+                  int_no_default:    [:integer],
+                  double_no_default: [:double]
                 }
       end
 
@@ -303,6 +305,8 @@ module OrigenTesters
             tm = test_methods.my_type_check.my_type_check_test
             tm.int    = '1'
             tm.double = '1.0'
+            tm.int_no_default = ''
+            tm.double_no_default = ''
             ts = test_suites.run(name, options)
             ts.test_method = tm
             flow.test ts, options

--- a/lib/origen_testers/test/interface.rb
+++ b/lib/origen_testers/test/interface.rb
@@ -85,7 +85,7 @@ module OrigenTesters
                 # this case.
                 my_type_check_test: {
                   # [OPTIONAL] The C++ test method class name can be overridden from the default like this:
-                  class_name: 'MyHashExampleClass',
+                  class_name:        'MyHashExampleClass',
                   int:               [:integer, 1],
                   double:            [:double,  1.0],
                   int_no_default:    [:integer],


### PR DESCRIPTION
Resolves SMT8 bug introduced in #222 where parameter of empty string will render as empty string (which is what we want on SMT7) which causes flow to not compile due to type mismatch.

Adds proper test cases for both SMT7 and SMT8.