### PR TITLE
smt7 looping restrictions on variable usage lifted

### DIFF
--- a/lib/origen_testers/smartest_based_tester/base/flow.rb
+++ b/lib/origen_testers/smartest_based_tester/base/flow.rb
@@ -491,21 +491,28 @@ module OrigenTesters
 
         def on_loop(node, options = {})
           start = node.to_a[0]
-          if start.is_a?(String)
+          if start.is_a?(String) || start.is_a?(Symbol)
             start = generate_flag_name(start)
             unless smt8?
               start = "@#{start}"
             end
           end
           stop = node.to_a[1]
-          if stop.is_a?(String) && smt8?
+          if stop.is_a?(String) || stop.is_a?(Symbol)
             stop = generate_flag_name(stop)
-          elsif stop.is_a?(String)
-            fail 'loops with \'stop\' defined as a variable cannot be supported in the defined environments.'
+            if tester.smt7?
+              stop = "@#{stop}"
+            end
           end
           step = node.to_a[2]
           if smt8? && !(step == -1 || step == 1)
             fail 'SMT8 does not support steps other than -1 or 1.'
+          end
+          if step.is_a?(String) || step.is_a?(Symbol)
+            step = generate_flag_name(step)
+            if tester.smt7?
+              step = "@#{step}"
+            end
           end
           if node.to_a[3].nil?
             fail 'You must supply a loop variable name!'
@@ -518,7 +525,7 @@ module OrigenTesters
           end
           # num = (stop - start) / step + 1
           # Handle increment/decrement
-          if step < 0
+          if step.is_a?(Numeric) && step < 0
             compare = '>'
             incdec = "- #{step * -1}"
           else
@@ -526,7 +533,10 @@ module OrigenTesters
             incdec = "+ #{step}"
           end
           if tester.smt7?
-            line "for #{var} = #{start}; #{var} #{compare} #{stop + step} ; #{var} = #{var} #{incdec}; do"
+            unless stop.is_a?(String)
+              stop = "#{stop + step}"
+            end
+            line "for #{var} = #{start}; #{var} #{compare} #{stop} ; #{var} = #{var} #{incdec}; do"
             line "test_number_loop_increment = #{test_num_inc}"
             line '{'
             @indent += 1

--- a/templates/origen_guides/program/flowapi.md.erb
+++ b/templates/origen_guides/program/flowapi.md.erb
@@ -406,8 +406,6 @@ Decrementing loops, having `from:` value > `to:` value and using negative `step:
 
 ##### Loop Rules For Each Environment
 
-`SMT7` cannot support a variable stop location. Only the `from:` parameter is allowed to be a variable.
-
 `SMT8` cannot have a step other than -1 or 1. The limitations of the range flow restrict those steps.
 The `to:` parameter can be a flow variable just like `from:`.
  


### PR DESCRIPTION
verified on an offline instance of SMT 7.10:

```
set :my_start_var, 0
set :my_stop_var, 10
set :my_step_var, 2

loop from: :my_start_var, to: :my_stop_var, step: :my_step_var, var: :my_loop_var do
  func :my_test
end
```

`my_test` successfully ran 5 times