### PR TITLE
v93k7/8 can disable subflow import grouping; enhanced startup/shutdown with flow options

### DIFF
--- a/approved/j750/prb1_flow.txt
+++ b/approved/j750/prb1_flow.txt
@@ -173,4 +173,7 @@ DFF 1.1	Flow Table
 						Test	meas_read_pump_v7	meas_read_pump	40080		119		2	Fail														
 						Test	meas_read_pump_v8	meas_read_pump	40090		119		2	Fail														
 						Test	on_deep_1							Fail									flag-true	deep_test_7AF57D1_FAILED				
+						Test	ungrouped_import_option_disable							Fail														
+						Test	ungrouped_flow_create_option_disable							Fail														
+						Test	grouped_flow_create_option_override							Fail														
 						set-device				1		1		Pass													Good die!	

--- a/approved/j750_hpt/prb1_flow.txt
+++ b/approved/j750_hpt/prb1_flow.txt
@@ -173,4 +173,7 @@ DFF 1.1	Flow Table
 						Test	meas_read_pump_v7	meas_read_pump	40080		119		2	Fail														
 						Test	meas_read_pump_v8	meas_read_pump	40090		119		2	Fail														
 						Test	on_deep_1							Fail									flag-true	deep_test_7AF57D1_FAILED				
+						Test	ungrouped_import_option_disable							Fail														
+						Test	ungrouped_flow_create_option_disable							Fail														
+						Test	grouped_flow_create_option_override							Fail														
 						set-device				1		1		Pass													Good die!	

--- a/approved/ultraflex/prb1_flow.txt
+++ b/approved/ultraflex/prb1_flow.txt
@@ -197,4 +197,7 @@ DTFlowtableSheet,version=2.2:platform=Jaguar:toprow=-1:leftcol=-1:rightcol=-1	Fl
 						logprint	Test_of_ultraflex_render_API																										
 						Use-Limit							Hz						Fail														
 						Test	on_deep_1												Fail									flag-true	deep_test_7AF57D1_FAILED				
+						Test	ungrouped_import_option_disable												Fail														
+						Test	ungrouped_flow_create_option_disable												Fail														
+						Test	grouped_flow_create_option_override												Fail														
 						set-device									1		1		Pass													Good die!	

--- a/approved/v93k/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k/testflow/mfh.testflow.group/prb1.tf
@@ -2430,6 +2430,11 @@ test_flow
     else
     {
     }
+    run(ungrouped_import_option_disable);
+    run(ungrouped_flow_create_option_disable);
+    {
+       run(grouped_flow_create_option_override);
+    }, open,"default_no_group_import", ""
     stop_bin "1", "", , good, noreprobe, green, 1, over_on;
 
   }, open,"PRB1",""

--- a/approved/v93k_disable_flow/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_disable_flow/testflow/mfh.testflow.group/prb1.tf
@@ -2306,6 +2306,11 @@ test_flow
        else
        {
        }
+       run(ungrouped_import_option_disable);
+       run(ungrouped_flow_create_option_disable);
+       {
+          run(grouped_flow_create_option_override);
+       }, open,"default_no_group_import", ""
        stop_bin "1", "", , good, noreprobe, green, 1, over_on;
     }
     else

--- a/approved/v93k_enable_flow/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_enable_flow/testflow/mfh.testflow.group/prb1.tf
@@ -2306,6 +2306,11 @@ test_flow
        else
        {
        }
+       run(ungrouped_import_option_disable);
+       run(ungrouped_flow_create_option_disable);
+       {
+          run(grouped_flow_create_option_override);
+       }, open,"default_no_group_import", ""
        stop_bin "1", "", , good, noreprobe, green, 1, over_on;
     }
     else

--- a/approved/v93k_flowgrouping/OrigenTesters/flows/PRB1.flow
+++ b/approved/v93k_flowgrouping/OrigenTesters/flows/PRB1.flow
@@ -76,6 +76,7 @@ flow PRB1 {
 
         flow PRB1_MAIN calls OrigenTesters.flows.prb1.PRB1_MAIN { }
         flow TEST calls OrigenTesters.flows.prb1.TEST { }
+        flow DEFAULT_NO_GROUP_IMPORT calls OrigenTesters.flows.prb1.DEFAULT_NO_GROUP_IMPORT { }
     }
 
     execute {
@@ -101,6 +102,9 @@ flow PRB1 {
             on_deep_1.execute();
         } else {
         }
+        ungrouped_import_option_disable.execute();
+        ungrouped_flow_create_option_disable.execute();
+        DEFAULT_NO_GROUP_IMPORT.execute();
         addBin(1);
     }
 }

--- a/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/DEFAULT_NO_GROUP_IMPORT.flow
+++ b/approved/v93k_flowgrouping/OrigenTesters/flows/prb1/DEFAULT_NO_GROUP_IMPORT.flow
@@ -1,0 +1,10 @@
+flow DEFAULT_NO_GROUP_IMPORT {
+
+
+    setup {
+    }
+
+    execute {
+        grouped_flow_create_option_override.execute();
+    }
+}

--- a/approved/v93k_flowgrouping/OrigenTesters/limits/Main.PRB1_Tests.csv
+++ b/approved/v93k_flowgrouping/OrigenTesters/limits/Main.PRB1_Tests.csv
@@ -121,3 +121,6 @@ TEST.meas_read_pump_4,meas_read_pump_4,40040,meas_read_pump_4,0.045,0.035,,2
 TEST.meas_read_pump_5,meas_read_pump_5,40050,meas_read_pump_5,0.045,0.035,,
 TEST.meas_read_pump_6,meas_read_pump_6,40060,meas_read_pump_6,2000,0.01,,
 on_deep_1,on_deep_1,,some_custom_text,0,0,,
+ungrouped_import_option_disable,ungrouped_import_option_disable,,ungrouped_import_option_disable,0,0,,
+ungrouped_flow_create_option_disable,ungrouped_flow_create_option_disable,,ungrouped_flow_create_option_disable,0,0,,
+DEFAULT_NO_GROUP_IMPORT.grouped_flow_create_option_override,grouped_flow_create_option_override,,grouped_flow_create_option_override,0,0,,

--- a/approved/v93k_global/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_global/testflow/mfh.testflow.group/prb1.tf
@@ -2304,6 +2304,11 @@ test_flow
     else
     {
     }
+    run(ungrouped_import_option_disable);
+    run(ungrouped_flow_create_option_disable);
+    {
+       run(grouped_flow_create_option_override);
+    }, open,"default_no_group_import", ""
     stop_bin "1", "", , good, noreprobe, green, 1, over_on;
 
   }, open,"PRB1",""

--- a/approved/v93k_multiport/testflow/mfh.testflow.group/prb1.tf
+++ b/approved/v93k_multiport/testflow/mfh.testflow.group/prb1.tf
@@ -2304,6 +2304,11 @@ test_flow
     else
     {
     }
+    run(ungrouped_import_option_disable);
+    run(ungrouped_flow_create_option_disable);
+    {
+       run(grouped_flow_create_option_override);
+    }, open,"default_no_group_import", ""
     stop_bin "1", "", , good, noreprobe, green, 1, over_on;
 
   }, open,"PRB1",""

--- a/approved/v93k_smt8/OrigenTesters/flows/PRB1.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/PRB1.flow
@@ -76,6 +76,7 @@ flow PRB1 {
 
         flow PRB1_MAIN calls OrigenTesters.flows.prb1.PRB1_MAIN { }
         flow TEST calls OrigenTesters.flows.prb1.TEST { }
+        flow DEFAULT_NO_GROUP_IMPORT calls OrigenTesters.flows.prb1.DEFAULT_NO_GROUP_IMPORT { }
     }
 
     execute {
@@ -94,6 +95,9 @@ flow PRB1 {
             on_deep_1.execute();
         } else {
         }
+        ungrouped_import_option_disable.execute();
+        ungrouped_flow_create_option_disable.execute();
+        DEFAULT_NO_GROUP_IMPORT.execute();
         addBin(1);
     }
 }

--- a/approved/v93k_smt8/OrigenTesters/flows/prb1/DEFAULT_NO_GROUP_IMPORT.flow
+++ b/approved/v93k_smt8/OrigenTesters/flows/prb1/DEFAULT_NO_GROUP_IMPORT.flow
@@ -1,0 +1,10 @@
+flow DEFAULT_NO_GROUP_IMPORT {
+
+
+    setup {
+    }
+
+    execute {
+        grouped_flow_create_option_override.execute();
+    }
+}

--- a/approved/v93k_smt8/OrigenTesters/limits/Main.PRB1_Tests.csv
+++ b/approved/v93k_smt8/OrigenTesters/limits/Main.PRB1_Tests.csv
@@ -121,3 +121,6 @@ TEST.meas_read_pump_4,meas_read_pump_4,40040,meas_read_pump_4,0.045,0.035,,2
 TEST.meas_read_pump_5,meas_read_pump_5,40050,meas_read_pump_5,0.045,0.035,,
 TEST.meas_read_pump_6,meas_read_pump_6,40060,meas_read_pump_6,2000,0.01,,
 on_deep_1,on_deep_1,,some_custom_text,0,0,,
+ungrouped_import_option_disable,ungrouped_import_option_disable,,ungrouped_import_option_disable,0,0,,
+ungrouped_flow_create_option_disable,ungrouped_flow_create_option_disable,,ungrouped_flow_create_option_disable,0,0,,
+DEFAULT_NO_GROUP_IMPORT.grouped_flow_create_option_override,grouped_flow_create_option_override,,grouped_flow_create_option_override,0,0,,

--- a/lib/origen_testers/generator.rb
+++ b/lib/origen_testers/generator.rb
@@ -258,6 +258,12 @@ module OrigenTesters
       options = {
         name: nil
       }.merge(options)
+
+      if !options.key?(:disable_group_on_sub_flow) &&
+         Origen.interface.instance_variable_get(:@disable_group_on_sub_flow)
+        options[:disable_group_on_sub_flow] = true
+      end
+
       file = Pathname.new(file).absolute? ? file : "#{current_dir}/#{file}"
       file = Origen.file_handler.add_rb_to(file)  # add .rb to filename if missing
       orig_file = "#{file}"     # capture original filename possibly without pre-pended underscore

--- a/lib/origen_testers/origen_ext/generator/flow.rb
+++ b/lib/origen_testers/origen_ext/generator/flow.rb
@@ -34,14 +34,21 @@ module Origen
         if OrigenTesters::Flow.flow_comments
           top = false
           name = options[:name] || Pathname.new(file).basename('.rb').to_s.sub(/^_/, '')
-          # Generate imports as separate sub-flow files on this platform
-          if tester.v93k? && tester.smt8?
-            parent, sub_flow = *_sub_flow(name, options, &block)
-            path = sub_flow.output_file.relative_path_from(Origen.file_handler.output_directory)
-            parent.atp.sub_flow(sub_flow.atp.raw, path: path.to_s)
+          import_options = Origen.generator.option_pipeline.last || {}
+          if import_options[:disable_group_on_sub_flow] ||
+             # runtime options passed to the import call take priority over Flow.create static options
+             (import_options[:disable_group_on_sub_flow].nil? && options[:disable_group])
+            _create(options, &block)
           else
-            Origen.interface.flow.group(name, description: flow_comments) do
-              _create(options, &block)
+            # Generate imports as separate sub-flow files on this platform
+            if tester.v93k? && tester.smt8?
+              parent, sub_flow = *_sub_flow(name, options, &block)
+              path = sub_flow.output_file.relative_path_from(Origen.file_handler.output_directory)
+              parent.atp.sub_flow(sub_flow.atp.raw, path: path.to_s)
+            else
+              Origen.interface.flow.group(name, description: flow_comments) do
+                _create(options, &block)
+              end
             end
           end
         else
@@ -62,6 +69,7 @@ module Origen
 
       # @api private
       def _sub_flow(name, options, &block)
+        Origen.interface._on_sub_flow(name, options) if Origen.interface.respond_to?(:_on_sub_flow)
         @top_level_flow ||= Origen.interface.flow
         parent = Origen.interface.flow
         # If the parent flow already has a child flow of this name then we need to generate a
@@ -113,9 +121,9 @@ module Origen
             Origen.app.reload_target!
             Origen.tester.generating = :program
           end
-          opts = Origen.generator.option_pipeline.pop || {}
+          options[:sub_flow_options] = Origen.generator.option_pipeline.pop || {}
           Origen.interface.startup(options) if Origen.interface.respond_to?(:startup)
-          interface.instance_exec(opts, &block)
+          interface.instance_exec(options[:sub_flow_options], &block)
           Origen.interface.shutdown(options) if Origen.interface.respond_to?(:shutdown)
           if Origen.tester.doc?
             Origen.interface.flow.stop_section

--- a/program/components/_default_group_import.rb
+++ b/program/components/_default_group_import.rb
@@ -1,0 +1,5 @@
+Flow.create do |options|
+
+  test :"#{options[:status]}_#{options[:type]}"
+
+end

--- a/program/components/_default_no_group_import.rb
+++ b/program/components/_default_no_group_import.rb
@@ -1,0 +1,5 @@
+Flow.create(disable_group: true) do |options|
+
+  test :"#{options[:status]}_#{options[:type]}"
+
+end

--- a/program/prb1.rb
+++ b/program/prb1.rb
@@ -19,5 +19,10 @@ Flow.create interface: 'OrigenTesters::Test::Interface', flow_description: 'Prob
   # Test that a reference to a deeply nested test works (mainly for SMT8)
   test :on_deep_1, if_failed: :deep_test, test_text: "some_custom_text"
 
+  import 'components/default_group_import',    type: 'import_option_disable', disable_group_on_sub_flow: true, status: :ungrouped
+  import 'components/default_no_group_import', type: 'flow_create_option_disable', status: :ungrouped
+  import 'components/default_no_group_import', type: 'flow_create_option_override', disable_group_on_sub_flow: false, status: :grouped
+
+
   pass 1, description: "Good die!", softbin: 1
 end

--- a/templates/origen_guides/program/v93ksmt7.md.erb
+++ b/templates/origen_guides/program/v93ksmt7.md.erb
@@ -110,6 +110,38 @@ end
 
 This same API may be used to implement similar features on other platforms in future, but for now only the V93K is implemented.
 
+#### Grouping on sub-flows
+
+By default, imported sub-flows are wrapped in a group named by the passed `:name` option if provided, otherwise the name of the file is used.
+
+~~~ruby
+import 'my_sub_flow' # sub flow contains single test 'my_test'
+
+# Results in the following output in the .tf file:
+#   {
+#      run(my_test);
+#   }, open,"my_sub_flow", ""
+~~~
+
+To disable this behavior, you can either pass to your import call the option `disable_group_on_sub_flow: true`,
+or set `disable_group: true` in your Flow.create() parameters:
+
+~~~ruby
+# Pass option to import
+import 'my_sub_flow', { disable_group_on_sub_flow: true }
+
+# Or set in Flow.create() in _my_sub_flow.rb
+Flow.create(disable_group: true) do
+  func :my_test
+end
+
+# Results in the following output in the .tf file:
+#   run(my_test);
+~~~
+
+Note that the import option takes priority, so if `Flow.create(disable_group: true)`
+is set but import is passed `disable_group_on_sub_flow: false` then a group will still be created.
+
 ### Test Name Uniqueness
 
 Test (suite) naming collisions can occur when importing multiple independent test flow modules into a

--- a/templates/origen_guides/program/v93ksmt8.md.erb
+++ b/templates/origen_guides/program/v93ksmt8.md.erb
@@ -55,7 +55,11 @@ Contains the limits tables for all flows.
 A top-level test program flow file in Origen will generate a correspondingly named file in the `flows/` directory,
 where the name of the generated file is the upper-cased version of the source file name.
 If the flow imports sub-flows or contains groups, then those will be contained in a directory named after the
-lower-cased version of the flow name.
+lower-cased version of the flow name. For sub-flow imports, this can be disabled by passing the option
+`disable_sub_flow_on_group: true` to the import call, or by setting the disable_group option in your sub-flow:
+`Flow.create(disable_group: true)`. Note that if both are provided, the import option value will take priority.
+When the group is disabled this way, the content of the sub-flow will simply be inserted as if it was defined
+in the calling flow instead of a sub flow.
 
 ##### limits/
 


### PR DESCRIPTION
We have some complex flows that benefit from an aggressive use of sub flows, which are looped over and call then call further sub flows, etc.

For V93k this can lead to a degraded user experience on the tester by having to dig through many nested groups to find the tests, or worse on smt8 a program that should reasonably have a dozen .flow files at most can end up with a couple hundred files to manage.

This gives the user the ability to opt out of that group creation on sub flow import.


Additionally, I have a use case that being able to interact with the flow options passed to the import statement just before Flow.create's block was processed was useful, so its now stored in the Flow.create's options so that startup and shutdown hooks have it available.


Lastly, I have yet another use case where I needed a way to intercept and interact with the options just before a group was applied but since SMT8 handles grouping differently, overriding the group method in my interface wasn't sufficient like it was for SMT7, so I added a hook to be called at the beginning of _on_sub_flow.